### PR TITLE
fix:resources can not read

### DIFF
--- a/src/greptimedb_mcp_server/server.py
+++ b/src/greptimedb_mcp_server/server.py
@@ -68,7 +68,7 @@ async def main(config: Config):
         if not uri_str.startswith("greptime://"):
             raise ValueError(f"Invalid URI scheme: {uri_str}")
 
-        parts = uri_str[8:].split('/')
+        parts = uri_str[11:].split('/')
         table = parts[0]
 
         try:
@@ -78,7 +78,7 @@ async def main(config: Config):
                     columns = [desc[0] for desc in cursor.description]
                     rows = cursor.fetchall()
                     result = [",".join(map(str, row)) for row in rows]
-                    return "\n".join([",".join(columns)] + result)
+            return "\n".join([",".join(columns)] + result)
 
         except Error as e:
             logger.error(f"Database error reading resource {uri}: {str(e)}")


### PR DESCRIPTION
I got a error `Database error: 1149 (42000): (InvalidSyntax): sql parser error: Expected identifier, found: : at Line: 1, Column 1` when run `read_resource`, I found the `uri_str` not update to `len("greptime://")`.

And I always got timeout, so I move the `return` to outside. I'm not sure it's right, but the timeout problem look like fixed.

It's working after fix:
![image](https://github.com/user-attachments/assets/99dd8bb7-2f50-4ff3-9453-5e8faacbadee)


Reference：
[MCP Inspector](https://modelcontextprotocol.io/docs/tools/inspector)