### PR TITLE
refactor: mcp server and test

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,17 @@ pip install -r requirements-dev.txt
 pytest
 ```
 
+Use [MCP Inspector](https://modelcontextprotocol.io/docs/tools/inspector) for debugging:
+
+```bash
+npx @modelcontextprotocol/inspector uv \
+  --directory \
+  /path/to/greptimedb-mcp-server \
+  run \
+  -m \
+  greptimedb_mcp_server.server
+```
+
 # Acknowledgement
 This library's implementation was inspired by the following two repositories and incorporates their code, for which we express our gratitude：
 

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,85 @@
+
+import pytest
+import sys
+
+# Mock classes for MySQL connection
+class MockCursor:
+    def __init__(self):
+        self.query = ""
+        self.rowcount = 2
+
+    def execute(self, query):
+        self.query = query
+
+    def fetchall(self):
+        if "SHOW TABLES" in self.query.upper():
+            return [('users',), ('orders',)]
+        elif "SELECT" in self.query.upper():
+            return [(1, 'John'), (2, 'Jane')]
+        return []
+
+    @property
+    def description(self):
+        if "SHOW TABLES" in self.query.upper():
+            return [('table_name', None)]
+        elif "SELECT" in self.query.upper():
+            return [('id', None), ('name', None)]
+        return []
+
+    def close(self):
+        pass
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        pass
+
+class MockConnection:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def cursor(self):
+        return MockCursor()
+
+    def commit(self):
+        pass
+
+    def close(self):
+        pass
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        pass
+
+class MockMySQLModule:
+    """Mock for entire mysql.connector module"""
+    @staticmethod
+    def connect(*args, **kwargs):
+        return MockConnection(*args, **kwargs)
+
+    class Error(Exception):
+        """Mock MySQL error class"""
+        pass
+
+def pytest_configure(config):
+    """
+    Called at the start of the pytest session, before tests are collected.
+    This is where we apply our global patches before any imports happen.
+    """
+    # Create and store original modules if they exist
+    original_mysql = sys.modules.get('mysql.connector')
+
+    # Create mock MySQL module
+    sys.modules['mysql.connector'] = MockMySQLModule
+
+    # Store the original function for later import and patching
+    config._mysql_original = original_mysql
+
+@pytest.hookimpl(trylast=True)
+def pytest_sessionfinish(session, exitstatus):
+    """Restore original modules after all tests are done"""
+    if hasattr(session.config, '_mysql_original') and session.config._mysql_original:
+        sys.modules['mysql.connector'] = session.config._mysql_original

--- a/src/greptimedb_mcp_server/__init__.py
+++ b/src/greptimedb_mcp_server/__init__.py
@@ -1,13 +1,13 @@
 from greptimedb_mcp_server.config import Config
-
 from . import server
-
 import asyncio
 
+
 def main():
-   """Main entry point for the package."""
-   config = Config.from_env_arguments()
-   asyncio.run(server.main(config))
+    """Main entry point for the package."""
+    config = Config.from_env_arguments()
+    asyncio.run(server.main(config))
+
 
 # Expose important items at package level
 __all__ = ['main', 'server']

--- a/src/greptimedb_mcp_server/config.py
+++ b/src/greptimedb_mcp_server/config.py
@@ -34,7 +34,6 @@ class Config:
     GreptimeDB database name
     """
 
-
     @staticmethod
     def from_env_arguments() -> "Config":
         """

--- a/src/greptimedb_mcp_server/server.py
+++ b/src/greptimedb_mcp_server/server.py
@@ -180,14 +180,11 @@ class DatabaseServer:
 async def main(config: Config):
     """Main entry point to run the MCP server."""
     logger = logging.getLogger("greptimedb_mcp_server")
-
     db_server = DatabaseServer(logger, config)
 
     logger.info("Starting GreptimeDB MCP server...")
 
     await db_server.run()
-
-
 
 if __name__ == "__main__":
     asyncio.run(main(Config.from_env_arguments()))

--- a/src/greptimedb_mcp_server/server.py
+++ b/src/greptimedb_mcp_server/server.py
@@ -9,6 +9,9 @@ from mcp.server import Server
 from mcp.types import Resource, Tool, TextContent
 from pydantic import AnyUrl
 
+# Resource URI prefix
+RES_PREFIX = "greptime://"
+
 # Configure logging
 logging.basicConfig(
     level=logging.INFO,
@@ -52,7 +55,7 @@ class DatabaseServer:
                     for table in tables:
                         resources.append(
                             Resource(
-                                uri=f"greptime://{table[0]}/data",
+                                uri=f"{RES_PREFIX}{table[0]}/data",
                                 name=f"Table: {table[0]}",
                                 mimeType="text/plain",
                                 description=f"Data in table: {table[0]}"
@@ -71,10 +74,10 @@ class DatabaseServer:
         uri_str = str(uri)
         logger.info(f"Reading resource: {uri_str}")
 
-        if not uri_str.startswith("greptime://"):
+        if not uri_str.startswith(RES_PREFIX):
             raise ValueError(f"Invalid URI scheme: {uri_str}")
 
-        parts = uri_str[11:].split('/')
+        parts = uri_str[len(RES_PREFIX):].split('/')
         table = parts[0]
 
         try:

--- a/src/greptimedb_mcp_server/server.py
+++ b/src/greptimedb_mcp_server/server.py
@@ -144,15 +144,16 @@ class DatabaseServer:
                 with conn.cursor() as cursor:
                     cursor.execute(query)
 
+                    stmt = query.strip().upper()
                     # Special handling for SHOW TABLES
-                    if query.strip().upper().startswith("SHOW TABLES"):
+                    if stmt.startswith("SHOW TABLES"):
                         tables = cursor.fetchall()
                         result = ["Tables_in_" + config["database"]]  # Header
                         result.extend([table[0] for table in tables])
                         return [TextContent(type="text", text="\n".join(result))]
 
                     # Regular SELECT queries
-                    elif query.strip().upper().startswith("SELECT") or query.strip().upper().startswith("DESCRIBE"):
+                    elif stmt.startswith("SELECT") or stmt.startswith("DESCRIBE"):
                         columns = [desc[0] for desc in cursor.description]
                         rows = cursor.fetchall()
                         result = [",".join(map(str, row)) for row in rows]

--- a/src/greptimedb_mcp_server/server.py
+++ b/src/greptimedb_mcp_server/server.py
@@ -8,7 +8,6 @@ from mysql.connector import connect, Error
 from mcp.server import Server
 from mcp.types import Resource, Tool, TextContent
 from pydantic import AnyUrl
-from typing import Optional, Dict, List
 
 # Resource URI prefix
 RES_PREFIX = "greptime://"
@@ -21,19 +20,20 @@ logging.basicConfig(
     format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
 )
 
+
 # The GreptimeDB MCP Server
 class DatabaseServer:
     def __init__(self, logger: Logger, config: Config):
         """Initialize the GreptimeDB MCP server"""
         self.app = Server("greptimedb_mcp_server")
         self.logger = logger
-        self.db_config =  {
+        self.db_config = {
             "host": config.host,
             "port": config.port,
             "user": config.user,
             "password": config.password,
             "database": config.database
-        };
+        }
 
         self.logger.info(f"GreptimeDB Config: {self.db_config}")
 
@@ -100,7 +100,6 @@ class DatabaseServer:
     async def list_tools(self) -> list[Tool]:
         """List available GreptimeDB tools."""
         logger = self.logger
-        config = self.db_config
 
         logger.info("Listing tools...")
         return [
@@ -135,7 +134,7 @@ class DatabaseServer:
             raise ValueError("Query is required")
 
         # Check if query is dangerous
-        is_dangerous,reason = security_gate(query=query)
+        is_dangerous, reason = security_gate(query=query)
         if is_dangerous:
             return [TextContent(type="text", text="Error: Contain dangerous operations, reason:" + reason)]
 
@@ -162,12 +161,12 @@ class DatabaseServer:
                     # Non-SELECT queries
                     else:
                         conn.commit()
-                        return [TextContent(type="text", text=f"Query executed successfully. Rows affected: {cursor.rowcount}")]
+                        return [TextContent(type="text",
+                                            text=f"Query executed successfully. Rows affected: {cursor.rowcount}")]
 
         except Error as e:
             logger.error(f"Error executing SQL '{query}': {e}")
             return [TextContent(type="text", text=f"Error executing query: {str(e)}")]
-
 
     async def run(self):
         """Run the MCP server."""
@@ -184,6 +183,7 @@ class DatabaseServer:
             except Exception as e:
                 logger.error(f"Server error: {str(e)}", exc_info=True)
                 raise
+
 
 async def main(config: Config):
     """Main entry point to run the MCP server."""

--- a/src/greptimedb_mcp_server/server.py
+++ b/src/greptimedb_mcp_server/server.py
@@ -152,7 +152,7 @@ class DatabaseServer:
                         return [TextContent(type="text", text="\n".join(result))]
 
                     # Regular SELECT queries
-                    elif query.strip().upper().startswith("SELECT"):
+                    elif query.strip().upper().startswith("SELECT") or query.strip().upper().startswith("DESCRIBE"):
                         columns = [desc[0] for desc in cursor.description]
                         rows = cursor.fetchall()
                         result = [",".join(map(str, row)) for row in rows]

--- a/src/greptimedb_mcp_server/utils.py
+++ b/src/greptimedb_mcp_server/utils.py
@@ -3,6 +3,7 @@ import logging
 
 logger = logging.getLogger("greptimedb_mcp_server")
 
+
 def security_gate(query: str) -> tuple[bool, str]:
     """
     Check if a SQL query is dangerous and should be blocked.

--- a/src/greptimedb_mcp_server/utils.py
+++ b/src/greptimedb_mcp_server/utils.py
@@ -6,26 +6,27 @@ logger = logging.getLogger("greptimedb_mcp_server")
 def security_gate(query: str) -> tuple[bool, str]:
     """
     Check if a SQL query is dangerous and should be blocked.
-    
+
     Args:
         query: The SQL query to check
-    
+
     Returns:
         tuple: A boolean indicating if the query is dangerous, and a reason message
     """
     # format query to uppercase and remove leading/trailing whitespace
     normalized_query = query.strip().upper()
-    
+
     # Define dangerous patterns
     dangerous_patterns = [
         (r'\bDROP\s', "Forbided `DROP` operation"),
         (r'\bDELETE\s', "Forbided `DELETE` operation"),
         (r'\bREVOKE\s', "Forbided `REVOKE` operation"),
+        (r'\bTRUNCATE\s', "Forbided `bTRUNCATE` operation"),
     ]
-    
+
     for pattern, reason in dangerous_patterns:
         if re.search(pattern, normalized_query):
             logger.warning(f"Detected dangerous operation: '{query}' - {reason}")
             return True, reason
-    
+
     return False, ""

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,8 +1,7 @@
 import os
-import pytest
-import sys
 from unittest.mock import patch
 from greptimedb_mcp_server.config import Config
+
 
 def test_config_default_values():
     """
@@ -17,6 +16,7 @@ def test_config_default_values():
             assert config.database == 'public'
             assert config.user == ''
             assert config.password == ''
+
 
 def test_config_env_variables():
     """
@@ -40,6 +40,7 @@ def test_config_env_variables():
             assert config.user == 'test_user'
             assert config.password == 'test_password'
 
+
 def test_config_cli_arguments():
     """
     Test configuration via command-line arguments
@@ -62,6 +63,7 @@ def test_config_cli_arguments():
             assert config.database == 'cli_db'
             assert config.user == 'cli_user'
             assert config.password == 'cli_password'
+
 
 def test_config_precedence():
     """
@@ -93,6 +95,7 @@ def test_config_precedence():
             assert config.database == 'cli_db'
             assert config.user == 'cli_user'
             assert config.password == 'cli_password'
+
 
 def test_config_object_creation():
     """

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,0 +1,111 @@
+
+import pytest
+import logging
+
+# Now we can safely import these
+from greptimedb_mcp_server.server import DatabaseServer
+from greptimedb_mcp_server.config import Config
+
+@pytest.fixture
+def config():
+    """Create a test configuration"""
+    return Config(
+        host="localhost",
+        port=4002,
+        user="testuser",
+        password="testpassword",
+        database="testdb"
+    )
+
+@pytest.fixture
+def logger():
+    """Create a test logger"""
+    return logging.getLogger("test_logger")
+
+@pytest.mark.asyncio
+async def test_list_resources(logger, config):
+    """Test listing database resources"""
+    server = DatabaseServer(logger, config)
+    resources = await server.list_resources()
+
+    # Verify the results
+    assert len(resources) == 2
+    assert resources[0].name == "Table: users"
+    assert str(resources[0].uri) == "greptime://users/data"
+
+@pytest.mark.asyncio
+async def test_read_resource(logger, config):
+    """Test reading a specific database resource"""
+    server = DatabaseServer(logger, config)
+    result = await server.read_resource("greptime://users/data")
+
+    # Verify the results contain expected data
+    assert "id,name" in result
+    assert "1,John" in result
+    assert "2,Jane" in result
+
+@pytest.mark.asyncio
+async def test_list_tools(logger, config):
+    """Test listing available database tools"""
+    server = DatabaseServer(logger, config)
+    tools = await server.list_tools()
+
+    # Verify the tool list
+    assert len(tools) == 1
+    assert tools[0].name == "execute_sql"
+    assert "query" in tools[0].inputSchema['properties']
+
+@pytest.mark.asyncio
+async def test_call_tool_select_query(logger, config):
+    """Test executing a SELECT query via tool"""
+    server = DatabaseServer(logger, config)
+    result = await server.call_tool(
+        "execute_sql",
+        {"query": "SELECT * FROM users"}
+    )
+
+    # Verify the results
+    assert len(result) == 1
+    assert "id,name" in result[0].text
+    assert "1,John" in result[0].text
+
+@pytest.mark.asyncio
+async def test_security_gate_dangerous_query(logger, config):
+    """Test security gate blocking dangerous queries"""
+    server = DatabaseServer(logger, config)
+
+    result = await server.call_tool(
+        "execute_sql",
+        {"query": "DROP TABLE users"}
+    )
+
+    # Verify that the security gate blocked the query
+    assert "Error: Contain dangerous operations" in result[0].text
+    assert "Forbided `DROP` operation" in result[0].text
+
+@pytest.mark.asyncio
+async def test_show_tables_query(logger, config):
+    """Test SHOW TABLES query execution"""
+    server = DatabaseServer(logger, config)
+    result = await server.call_tool(
+        "execute_sql",
+        {"query": "SHOW TABLES"}
+    )
+
+    # Verify the results
+    assert len(result) == 1
+    assert "Tables_in_testdb" in result[0].text
+    assert "users" in result[0].text
+    assert "orders" in result[0].text
+
+def test_server_initialization(logger, config):
+    """Test server initialization with configuration"""
+    server = DatabaseServer(logger, config)
+
+    # Verify the server was initialized correctly
+    assert server.logger == logger
+    assert server.db_config['host'] == 'localhost'
+    assert server.db_config['port'] == 4002
+    assert server.db_config['user'] == 'testuser'
+    assert server.db_config['password'] == 'testpassword'
+    assert server.db_config['database'] == 'testdb'

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -6,6 +6,7 @@ import logging
 from greptimedb_mcp_server.server import DatabaseServer
 from greptimedb_mcp_server.config import Config
 
+
 @pytest.fixture
 def config():
     """Create a test configuration"""
@@ -17,10 +18,12 @@ def config():
         database="testdb"
     )
 
+
 @pytest.fixture
 def logger():
     """Create a test logger"""
     return logging.getLogger("test_logger")
+
 
 @pytest.mark.asyncio
 async def test_list_resources(logger, config):
@@ -33,6 +36,7 @@ async def test_list_resources(logger, config):
     assert resources[0].name == "Table: users"
     assert str(resources[0].uri) == "greptime://users/data"
 
+
 @pytest.mark.asyncio
 async def test_read_resource(logger, config):
     """Test reading a specific database resource"""
@@ -44,6 +48,7 @@ async def test_read_resource(logger, config):
     assert "1,John" in result
     assert "2,Jane" in result
 
+
 @pytest.mark.asyncio
 async def test_list_tools(logger, config):
     """Test listing available database tools"""
@@ -54,6 +59,7 @@ async def test_list_tools(logger, config):
     assert len(tools) == 1
     assert tools[0].name == "execute_sql"
     assert "query" in tools[0].inputSchema['properties']
+
 
 @pytest.mark.asyncio
 async def test_call_tool_select_query(logger, config):
@@ -69,6 +75,7 @@ async def test_call_tool_select_query(logger, config):
     assert "id,name" in result[0].text
     assert "1,John" in result[0].text
 
+
 @pytest.mark.asyncio
 async def test_security_gate_dangerous_query(logger, config):
     """Test security gate blocking dangerous queries"""
@@ -82,6 +89,7 @@ async def test_security_gate_dangerous_query(logger, config):
     # Verify that the security gate blocked the query
     assert "Error: Contain dangerous operations" in result[0].text
     assert "Forbided `DROP` operation" in result[0].text
+
 
 @pytest.mark.asyncio
 async def test_show_tables_query(logger, config):
@@ -97,6 +105,7 @@ async def test_show_tables_query(logger, config):
     assert "Tables_in_testdb" in result[0].text
     assert "users" in result[0].text
     assert "orders" in result[0].text
+
 
 def test_server_initialization(logger, config):
     """Test server initialization with configuration"""


### PR DESCRIPTION
Main changes:

* refactor server for unit tests
* add unit tests for server
* forbid `truncate` operation
* render `describe table` results
* adds MySQL dialect to tool prompt