### PR TITLE
Avoid  RuntimeWarning while using uv -m or python -m to run

### DIFF
--- a/src/greptimedb_mcp_server/__init__.py
+++ b/src/greptimedb_mcp_server/__init__.py
@@ -1,5 +1,7 @@
 from greptimedb_mcp_server.config import Config
-from . import server
+import sys
+if not '-m' in sys.argv:
+    from . import server
 import asyncio
 
 

--- a/src/greptimedb_mcp_server/__init__.py
+++ b/src/greptimedb_mcp_server/__init__.py
@@ -1,6 +1,7 @@
 from greptimedb_mcp_server.config import Config
 import sys
-if not '-m' in sys.argv:
+
+if not "-m" in sys.argv:
     from . import server
 import asyncio
 


### PR DESCRIPTION
Without this change, i may get `<frozen runpy>:128: RuntimeWarning: XXXXX found in sys.modules after import of package XXXX, but prior to execution of XXXXX; this may result in unpredictable behaviour`