### PR TITLE
feat: supports time_zone and show,tql eval etc.

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ GREPTIMEDB_PORT=4002         # Optional: Database MySQL port (defaults to 4002 i
 GREPTIMEDB_USER=root
 GREPTIMEDB_PASSWORD=
 GREPTIMEDB_DATABASE=public
+GREPTIMEDB_TIMEZONE=UTC
 ```
 
 Or via command-line args:
@@ -46,6 +47,7 @@ Or via command-line args:
 * `--user` the database username, empty by default,
 * `--password` the database password, empty by default,
 * `--database` the database name, `public` by default.
+* `--timezone` the session time zone, empty by default(using server default time zone).
 
 # Usage
 
@@ -79,7 +81,8 @@ Location: `%APPDATA%/Claude/claude_desktop_config.json`
         "GREPTIMEDB_PORT": "4002",
         "GREPTIMEDB_USER": "root",
         "GREPTIMEDB_PASSWORD": "",
-        "GREPTIMEDB_DATABASE": "public"
+        "GREPTIMEDB_DATABASE": "public",
+        "GREPTIMEDB_TIMEZONE": ""
       }
     }
   }

--- a/conftest.py
+++ b/conftest.py
@@ -24,7 +24,7 @@ class MockCursor:
     def description(self):
         if "SHOW TABLES" in self.query.upper():
             return [("table_name", None)]
-        elif "SHOW TABLES" in self.query.upper():
+        elif "SHOW DATABASES" in self.query.upper():
             return [("Databases", None)]
         elif "SELECT" in self.query.upper():
             return [("id", None), ("name", None)]

--- a/conftest.py
+++ b/conftest.py
@@ -14,6 +14,8 @@ class MockCursor:
     def fetchall(self):
         if "SHOW TABLES" in self.query.upper():
             return [("users",), ("orders",)]
+        elif "SHOW DATABASES" in self.query.upper():
+            return [("public",), ("greptime_private",)]
         elif "SELECT" in self.query.upper():
             return [(1, "John"), (2, "Jane")]
         return []
@@ -22,6 +24,8 @@ class MockCursor:
     def description(self):
         if "SHOW TABLES" in self.query.upper():
             return [("table_name", None)]
+        elif "SHOW TABLES" in self.query.upper():
+            return [("Databases", None)]
         elif "SELECT" in self.query.upper():
             return [("id", None), ("name", None)]
         return []

--- a/src/greptimedb_mcp_server/config.py
+++ b/src/greptimedb_mcp_server/config.py
@@ -34,6 +34,11 @@ class Config:
     GreptimeDB database name
     """
 
+    time_zone: str
+    """
+    GreptimeDB session time zone
+    """
+
     @staticmethod
     def from_env_arguments() -> "Config":
         """
@@ -76,6 +81,13 @@ class Config:
             default=os.getenv("GREPTIMEDB_PASSWORD", ""),
         )
 
+        parser.add_argument(
+            "--timezone",
+            type=str,
+            help="GreptimeDB session time zone",
+            default=os.getenv("GREPTIMEDB_TIMEZONE", ""),
+        )
+
         args = parser.parse_args()
         return Config(
             host=args.host,
@@ -83,4 +95,5 @@ class Config:
             database=args.database,
             user=args.user,
             password=args.password,
+            time_zone=args.timezone,
         )

--- a/src/greptimedb_mcp_server/server.py
+++ b/src/greptimedb_mcp_server/server.py
@@ -219,12 +219,10 @@ class DatabaseServer:
                         result = ["Tables_in_" + config["database"]]  # Header
                         result.extend([table[0] for table in tables])
                         return [TextContent(type="text", text="\n".join(result))]
-                    # Regular SELECT queries
-                    elif (
-                        stmt.startswith("SELECT")
-                        or stmt.startswith("SHOW")
-                        or stmt.startswith("DESC")
-                        or stmt.startswith("TQL EVAL")
+                    # Regular queries
+                    elif any(
+                        stmt.startswith(cmd)
+                        for cmd in ["SELECT", "SHOW", "DESC", "TQL", "EXPLAIN"]
                     ):
                         columns = [desc[0] for desc in cursor.description]
                         rows = cursor.fetchall()

--- a/src/greptimedb_mcp_server/server.py
+++ b/src/greptimedb_mcp_server/server.py
@@ -207,7 +207,7 @@ class DatabaseServer:
                     cursor.execute(query)
 
                     stmt = query.strip().upper()
-                    # Special handling for SHOW TABLES
+                    # Special handling for SHOW DATABASES
                     if stmt.startswith("SHOW DATABASES"):
                         dbs = cursor.fetchall()
                         result = ["Databases"]  # Header

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -16,6 +16,7 @@ def test_config_default_values():
             assert config.database == "public"
             assert config.user == ""
             assert config.password == ""
+            assert config.time_zone == ""
 
 
 def test_config_env_variables():
@@ -28,6 +29,7 @@ def test_config_env_variables():
         "GREPTIMEDB_DATABASE": "test_db",
         "GREPTIMEDB_USER": "test_user",
         "GREPTIMEDB_PASSWORD": "test_password",
+        "GREPTIMEDB_TIMEZONE": "test_tz",
     }
 
     with patch.dict(os.environ, env_vars):
@@ -39,6 +41,7 @@ def test_config_env_variables():
             assert config.database == "test_db"
             assert config.user == "test_user"
             assert config.password == "test_password"
+            assert config.time_zone == "test_tz"
 
 
 def test_config_cli_arguments():
@@ -57,6 +60,8 @@ def test_config_cli_arguments():
         "cli_user",
         "--password",
         "cli_password",
+        "--timezone",
+        "cli_tz",
     ]
 
     with patch.dict(os.environ, {}, clear=True):
@@ -68,6 +73,7 @@ def test_config_cli_arguments():
             assert config.database == "cli_db"
             assert config.user == "cli_user"
             assert config.password == "cli_password"
+            assert config.time_zone == "cli_tz"
 
 
 def test_config_precedence():
@@ -80,6 +86,7 @@ def test_config_precedence():
         "GREPTIMEDB_DATABASE": "env_db",
         "GREPTIMEDB_USER": "env_user",
         "GREPTIMEDB_PASSWORD": "env_password",
+        "GREPTIMEDB_TIMEZONE": "env_tz",
     }
 
     cli_args = [
@@ -94,6 +101,8 @@ def test_config_precedence():
         "cli_user",
         "--password",
         "cli_password",
+        "--timezone",
+        "cli_tz",
     ]
 
     with patch.dict(os.environ, env_vars):
@@ -105,6 +114,7 @@ def test_config_precedence():
             assert config.database == "cli_db"
             assert config.user == "cli_user"
             assert config.password == "cli_password"
+            assert config.time_zone == "cli_tz"
 
 
 def test_config_object_creation():
@@ -117,6 +127,7 @@ def test_config_object_creation():
         database="manual_db",
         user="manual_user",
         password="manual_password",
+        time_zone="manual_timezone"
     )
 
     assert config.host == "manual-host"
@@ -124,3 +135,4 @@ def test_config_object_creation():
     assert config.database == "manual_db"
     assert config.user == "manual_user"
     assert config.password == "manual_password"
+    assert config.time_zone == "manual_timezone"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -127,7 +127,7 @@ def test_config_object_creation():
         database="manual_db",
         user="manual_user",
         password="manual_password",
-        time_zone="manual_timezone"
+        time_zone="manual_timezone",
     )
 
     assert config.host == "manual-host"

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -15,6 +15,7 @@ def config():
         user="testuser",
         password="testpassword",
         database="testdb",
+        time_zone="",
     )
 
 
@@ -95,6 +96,18 @@ async def test_show_tables_query(logger, config):
     assert "Tables_in_testdb" in result[0].text
     assert "users" in result[0].text
     assert "orders" in result[0].text
+
+@pytest.mark.asyncio
+async def test_show_dbs_query(logger, config):
+    """Test SHOW TABLES query execution"""
+    server = DatabaseServer(logger, config)
+    result = await server.call_tool("execute_sql", {"query": "SHOW DATABASES"})
+
+    # Verify the results
+    assert len(result) == 1
+    assert "Databases" in result[0].text
+    print(result[0].text)
+    assert "public" in result[0].text
 
 
 @pytest.mark.asyncio

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -97,6 +97,7 @@ async def test_show_tables_query(logger, config):
     assert "users" in result[0].text
     assert "orders" in result[0].text
 
+
 @pytest.mark.asyncio
 async def test_show_dbs_query(logger, config):
     """Test SHOW TABLES query execution"""

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -100,7 +100,7 @@ async def test_show_tables_query(logger, config):
 
 @pytest.mark.asyncio
 async def test_show_dbs_query(logger, config):
-    """Test SHOW TABLES query execution"""
+    """Test SHOW DATABASES query execution"""
     server = DatabaseServer(logger, config)
     result = await server.call_tool("execute_sql", {"query": "SHOW DATABASES"})
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -109,6 +109,7 @@ async def test_show_dbs_query(logger, config):
     assert "Databases" in result[0].text
     print(result[0].text)
     assert "public" in result[0].text
+    assert "greptime_private" in result[0].text
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
* Supports `time_zone` setting, but depends on https://github.com/GreptimeTeam/greptimedb/issues/6207
* `call_tool` supports `show`, `desc table`, `tql`, `explain` and `show databases` statements.