### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ A Model Context Protocol (MCP) server for [GreptimeDB](https://github.com/Grepti
 
 Enables AI assistants to query and analyze GreptimeDB using SQL, TQL (PromQL-compatible), and RANGE queries, with built-in security features like read-only enforcement and data masking.
 
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/greptimeteam-greptimedb-mcp-server).
+
 ## Quick Start
 
 ```bash


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/greptimeteam-greptimedb-mcp-server).