### PR TITLE
Enhance describe_table with table profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ For Claude Desktop, add this to your config (`~/Library/Application Support/Clau
 | `execute_sql` | Execute SQL queries with format (csv/json/markdown) and limit options |
 | `execute_tql` | Execute TQL (PromQL-compatible) queries for time-series analysis |
 | `query_range` | Execute time-window aggregation queries with RANGE/ALIGN syntax |
-| `describe_table` | Get table schema including column names, types, and constraints |
+| `describe_table` | Inspect a table profile: schema, semantic metadata, latest sample rows, and query guidance |
 | `explain_query` | Analyze SQL or TQL query execution plans |
 | `health_check` | Check database connection status and server version |
 

--- a/conftest.py
+++ b/conftest.py
@@ -18,6 +18,29 @@ class MockCursor:
             self._results = [("users",), ("orders",)]
         elif "SHOW DATABASES" in self.query.upper():
             self._results = [("public",), ("greptime_private",)]
+        elif "INFORMATION_SCHEMA.COLUMNS" in self.query.upper():
+            self._results = [
+                ("id", "Int64", "TAG", "NO"),
+                ("name", "String", "FIELD", "YES"),
+                ("ts", "TimestampMillisecond", "TIMESTAMP", "NO"),
+            ]
+        elif "INFORMATION_SCHEMA.TABLE_SEMANTICS" in self.query.upper():
+            if args and args[1] == "users":
+                self._results = [
+                    (
+                        "greptime",
+                        args[0],
+                        args[1],
+                        1024,
+                        "metric",
+                        "opentelemetry",
+                        "",
+                        "declared",
+                        '{"metric.type":"counter","metric.unit":"By"}',
+                    )
+                ]
+            else:
+                self._results = []
         elif "DESCRIBE" in self.query.upper():
             self._results = [
                 ("id", "Int64", "", "PRI", "", ""),
@@ -46,6 +69,11 @@ class MockCursor:
         elif "GREPTIME_PRIVATE.PIPELINES" in self.query.upper():
             # Pipeline list query - returns empty by default
             self._results = []
+        elif "SELECT * FROM" in self.query.upper():
+            self._results = [
+                (1, "John", "2024-01-01 00:00:00"),
+                (2, "Jane", "2024-01-01 00:01:00"),
+            ]
         elif "SELECT" in self.query.upper():
             self._results = [(1, "John"), (2, "Jane")]
         else:
@@ -85,6 +113,25 @@ class MockCursor:
                 ("Default", None),
                 ("Semantic Type", None),
             ]
+        elif "INFORMATION_SCHEMA.COLUMNS" in self.query.upper():
+            return [
+                ("column_name", None),
+                ("data_type", None),
+                ("semantic_type", None),
+                ("is_nullable", None),
+            ]
+        elif "INFORMATION_SCHEMA.TABLE_SEMANTICS" in self.query.upper():
+            return [
+                ("table_catalog", None),
+                ("table_schema", None),
+                ("table_name", None),
+                ("table_id", None),
+                ("signal_type", None),
+                ("source", None),
+                ("pipeline", None),
+                ("metadata_quality", None),
+                ("semantic_options", None),
+            ]
         elif "VERSION()" in self.query.upper():
             return [("version()", None)]
         elif "TQL" in self.query.upper():
@@ -95,6 +142,8 @@ class MockCursor:
             return [("ts", None), ("host", None), ("avg_cpu", None)]
         elif "GREPTIME_PRIVATE.PIPELINES" in self.query.upper():
             return [("name", None), ("pipeline", None), ("version", None)]
+        elif "SELECT * FROM" in self.query.upper():
+            return [("id", None), ("name", None), ("ts", None)]
         elif "SELECT" in self.query.upper():
             return [("id", None), ("name", None)]
         return []

--- a/docs/llm-instructions.md
+++ b/docs/llm-instructions.md
@@ -11,7 +11,7 @@ You have access to a GreptimeDB MCP server for querying and managing time-series
 - `execute_sql`: Run SQL queries (SELECT, SHOW, DESCRIBE only - read-only access)
 - `execute_tql`: Run PromQL-compatible time-series queries
 - `query_range`: Time-window aggregation with RANGE/ALIGN syntax
-- `describe_table`: Get table schema information
+- `describe_table`: Inspect a table profile: schema, semantic metadata, latest sample rows, and query guidance
 - `health_check`: Check database connection status
 - `explain_query`: Analyze query execution plans
 
@@ -41,7 +41,7 @@ Use these prompts for specialized tasks:
 ## Workflow Tips
 1. For log pipeline creation: Get log sample → use `pipeline_creator` prompt → generate YAML → `create_pipeline` → `dryrun_pipeline` to verify
 2. For dashboard creation: Prepare Perses JSON definition → `create_dashboard` → verify with `list_dashboards`
-3. For data analysis: `describe_table` first → understand schema → `execute_sql` or `execute_tql`
+3. For data analysis: `describe_table` first → understand schema, semantics, and sample rows → `execute_sql` or `execute_tql`
 4. For time-series: Prefer `query_range` for aggregations, `execute_tql` for PromQL patterns
 5. Always check `health_check` if queries fail unexpectedly
 ```

--- a/src/greptimedb_mcp_server/server.py
+++ b/src/greptimedb_mcp_server/server.py
@@ -43,6 +43,7 @@ from mysql.connector.pooling import MySQLConnectionPool
 RES_PREFIX = "greptime://"
 RESULTS_LIMIT = 100
 MAX_QUERY_LIMIT = 10000
+MAX_SAMPLE_LIMIT = 20
 
 # Configure logging
 logging.basicConfig(
@@ -113,6 +114,32 @@ def get_state() -> AppState:
     if _state is None:
         raise RuntimeError("Application state not initialized")
     return _state
+
+
+def _split_table_reference(table: str, default_schema: str) -> tuple[str, str]:
+    parts = table.split(".", 1)
+    if len(parts) == 2:
+        return parts[0], parts[1]
+    return default_schema, table
+
+
+def _quote_identifier(name: str) -> str:
+    return f"`{name.replace('`', '``')}`"
+
+
+def _quote_table_reference(table: str) -> str:
+    return ".".join(_quote_identifier(part) for part in table.split("."))
+
+
+def _normalize_nullable(value) -> bool | None:
+    if value is None:
+        return None
+    text = str(value).upper()
+    if text in {"YES", "Y", "TRUE", "1"}:
+        return True
+    if text in {"NO", "N", "FALSE", "0"}:
+        return False
+    return None
 
 
 @asynccontextmanager
@@ -294,24 +321,233 @@ async def execute_sql(
 @mcp.tool()
 async def describe_table(
     table: Annotated[str, "Table name to describe (supports schema.table format)"],
+    include_semantics: Annotated[
+        bool,
+        "Include table semantic metadata from information_schema.table_semantics",
+    ] = True,
+    include_samples: Annotated[
+        bool,
+        "Include a small sample of table rows for context",
+    ] = True,
+    sample_limit: Annotated[
+        int,
+        f"Maximum sample rows to return (0-{MAX_SAMPLE_LIMIT}, default: 5)",
+    ] = 5,
 ) -> str:
-    """Get table schema information including column names, types, and constraints."""
+    """Get a table profile: schema, semantic metadata, sample rows, and guidance."""
     state = get_state()
     table = validate_table_name(table)
+    sample_limit = max(0, min(sample_limit, MAX_SAMPLE_LIMIT))
+    table_schema, table_name = _split_table_reference(table, state.db_config["database"])
+
+    def _fetch_schema(cursor) -> dict:
+        cursor.execute(
+            """
+            SELECT column_name, data_type, semantic_type, is_nullable
+            FROM information_schema.columns
+            WHERE table_schema = %s AND table_name = %s
+            ORDER BY ordinal_position
+            """,
+            (table_schema, table_name),
+        )
+        rows = cursor.fetchall()
+        columns = []
+        time_index = None
+        primary_keys = []
+        for row in rows:
+            column_name, data_type, semantic_type, is_nullable = row[:4]
+            semantic_type_text = str(semantic_type).upper() if semantic_type else ""
+            if semantic_type_text == "TIMESTAMP":
+                time_index = column_name
+            elif semantic_type_text in {"TAG", "PRIMARY KEY", "PRIMARY_KEY"}:
+                primary_keys.append(column_name)
+            columns.append(
+                {
+                    "name": column_name,
+                    "data_type": data_type,
+                    "semantic_type": semantic_type,
+                    "nullable": _normalize_nullable(is_nullable),
+                }
+            )
+        return {
+            "columns": columns,
+            "time_index": time_index,
+            "primary_keys": primary_keys,
+        }
+
+    def _fetch_semantics(cursor) -> dict:
+        if not include_semantics:
+            return {"included": False}
+        try:
+            cursor.execute(
+                """
+                SELECT table_catalog, table_schema, table_name, table_id,
+                       signal_type, source, pipeline, metadata_quality,
+                       semantic_options
+                FROM information_schema.table_semantics
+                WHERE table_schema = %s AND table_name = %s
+                """,
+                (table_schema, table_name),
+            )
+            row = cursor.fetchone()
+        except Error as e:
+            return {
+                "included": True,
+                "available": False,
+                "found": False,
+                "error": str(e),
+            }
+
+        if not row:
+            return {"included": True, "available": True, "found": False}
+
+        semantic_options = row[8]
+        options = {}
+        raw_options = None
+        parse_error = None
+        if semantic_options:
+            try:
+                options = json.loads(semantic_options)
+            except (TypeError, json.JSONDecodeError) as e:
+                raw_options = semantic_options
+                parse_error = str(e)
+
+        result = {
+            "included": True,
+            "available": True,
+            "found": True,
+            "table_catalog": row[0],
+            "table_schema": row[1],
+            "table_name": row[2],
+            "table_id": row[3],
+            "signal_type": row[4],
+            "source": row[5],
+            "pipeline": row[6],
+            "metadata_quality": row[7],
+            "options": options,
+        }
+        if raw_options is not None:
+            result["raw_options"] = raw_options
+            result["options_parse_error"] = parse_error
+        return result
+
+    def _fetch_samples(cursor, schema: dict) -> dict:
+        if not include_samples:
+            return {"included": False}
+        if sample_limit == 0:
+            return {"included": True, "limit": 0, "columns": [], "rows": []}
+
+        try:
+            quoted_table = _quote_table_reference(table)
+            time_index = schema.get("time_index")
+            if time_index:
+                strategy = "latest_by_time_index"
+                query = (
+                    f"SELECT * FROM {quoted_table} "
+                    f"ORDER BY {_quote_identifier(time_index)} DESC LIMIT %s"
+                )
+            else:
+                strategy = "plain_limit"
+                query = f"SELECT * FROM {quoted_table} LIMIT %s"
+
+            cursor.execute(query, (sample_limit,))
+            columns = [desc[0] for desc in cursor.description]
+            rows = cursor.fetchall()
+            formatted = format_results(
+                columns,
+                rows,
+                "json",
+                mask_enabled=state.mask_enabled,
+                mask_patterns=state.mask_patterns,
+            )
+            return {
+                "included": True,
+                "strategy": strategy,
+                "limit": sample_limit,
+                "columns": columns,
+                "rows": json.loads(formatted),
+            }
+        except Error as e:
+            return {
+                "included": True,
+                "limit": sample_limit,
+                "columns": [],
+                "rows": [],
+                "error": str(e),
+            }
+
+    def _build_guidance(schema: dict, semantics: dict, samples: dict) -> list[str]:
+        guidance = []
+        if semantics.get("included") and not semantics.get("available", True):
+            guidance.append(
+                "Table semantic metadata is unavailable. The connected GreptimeDB "
+                "version may not support information_schema.table_semantics."
+            )
+        elif semantics.get("included") and not semantics.get("found"):
+            guidance.append(
+                "No table semantic metadata was found. Treat signal type and "
+                "query pattern as schema/sample-based inference."
+            )
+
+        signal_type = semantics.get("signal_type")
+        options = semantics.get("options") or {}
+        metric_type = options.get("metric.type")
+        metadata_quality = semantics.get("metadata_quality")
+
+        if signal_type == "metric":
+            if metric_type == "counter":
+                guidance.append(
+                    "This table is a counter metric. Prefer rate or increase "
+                    "queries for trend analysis."
+                )
+            elif metric_type == "gauge":
+                guidance.append(
+                    "This table is a gauge metric. Prefer absolute value, avg, "
+                    "min, max, or percentile analysis."
+                )
+            elif metric_type == "histogram":
+                guidance.append(
+                    "This table is a histogram metric. Prefer bucket/count/sum "
+                    "based percentile analysis."
+                )
+            if metadata_quality == "inferred":
+                guidance.append(
+                    "Metric type was inferred from naming. Re-check the query "
+                    "choice if the metric name is non-standard."
+                )
+        elif signal_type == "trace":
+            guidance.append(
+                "This table represents traces. Prefer latency, error span, and "
+                "service-level aggregation queries."
+            )
+        elif signal_type == "log":
+            guidance.append(
+                "This table represents logs. Prefer full-text search plus "
+                "severity, time, and service aggregations."
+            )
+
+        if samples.get("included") and samples.get("strategy") == "latest_by_time_index":
+            guidance.append(
+                f"Sample rows are ordered by time index {schema.get('time_index')} descending."
+            )
+        return guidance
 
     def _sync_describe():
         with state.get_connection() as conn:
             with conn.cursor() as cursor:
-                cursor.execute(f"DESCRIBE {table}")
-                columns = [desc[0] for desc in cursor.description]
-                rows = cursor.fetchall()
-                return format_results(
-                    columns,
-                    rows,
-                    "markdown",
-                    mask_enabled=state.mask_enabled,
-                    mask_patterns=state.mask_patterns,
-                )
+                schema = _fetch_schema(cursor)
+                semantics = _fetch_semantics(cursor)
+                samples = _fetch_samples(cursor, schema)
+                result = {
+                    "table": table,
+                    "table_schema": table_schema,
+                    "table_name": table_name,
+                    "schema": schema,
+                    "semantics": semantics,
+                    "samples": samples,
+                    "guidance": _build_guidance(schema, semantics, samples),
+                }
+                return json.dumps(result, ensure_ascii=False, indent=2, default=str)
 
     try:
         return await asyncio.to_thread(_sync_describe)

--- a/src/greptimedb_mcp_server/templates/metrics_analysis/template.md
+++ b/src/greptimedb_mcp_server/templates/metrics_analysis/template.md
@@ -7,14 +7,14 @@ Analyze metrics data from GreptimeDB for topic: {{ topic }}
 ## Available Tools
 
 - `execute_sql` - Execute SQL queries (MySQL syntax)
-- `describe_table` - Get table schema
+- `describe_table` - Inspect table profile: schema, semantics, and sample rows
 - `execute_tql` - Execute PromQL-compatible queries
 - `query_range` - Time-window aggregations with RANGE syntax
 
 ## Guidelines
 
 1. Always filter by time range for time-series queries
-2. Use `DESCRIBE table_name` to explore schema first
+2. Use `describe_table` first to inspect schema, semantic metadata, and sample rows
 3. Use aggregation functions: avg, max, min, sum, count, stddev
 4. Results are read-only; write operations are blocked
 
@@ -24,8 +24,8 @@ Analyze metrics data from GreptimeDB for topic: {{ topic }}
 -- List tables
 SHOW TABLES;
 
--- Get schema
-DESCRIBE your_table;
+-- Get table profile with schema, semantics, and sample rows
+-- Use describe_table(table="your_table")
 
 -- Recent data sample
 SELECT * FROM your_table

--- a/src/greptimedb_mcp_server/templates/table_operation/template.md
+++ b/src/greptimedb_mcp_server/templates/table_operation/template.md
@@ -4,18 +4,23 @@ Analyze table structure, region health, storage, and query performance.
 
 ## Available Tools
 
-- `describe_table` - Get table schema
+- `describe_table` - Inspect table profile: schema, semantic metadata, sample rows
 - `explain_query` - Analyze query execution plan (set `analyze=true` for runtime stats)
 - `execute_sql` - Run diagnostic SQL queries
 
 ## Schema Analysis
 
 ```sql
--- Table structure
-DESCRIBE {{ table }};
+-- Table profile
+-- Use describe_table(table="{{ table }}") for schema, semantics, and sample rows.
 
 -- Full DDL
 SHOW CREATE TABLE {{ table }};
+
+-- Table semantic metadata, if supported by this GreptimeDB version
+SELECT table_schema, table_name, signal_type, source, pipeline, metadata_quality, semantic_options
+FROM information_schema.table_semantics
+WHERE table_name = '{{ table }}';
 
 -- Column details
 SELECT column_name, data_type, semantic_type, is_nullable

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -173,12 +173,116 @@ async def test_execute_sql_union_allowed():
 
 @pytest.mark.asyncio
 async def test_describe_table():
-    """Test describe_table tool"""
+    """Test describe_table tool returns schema, semantics, samples, and guidance."""
     result = await describe_table(table="users")
+    data = json.loads(result)
 
-    assert "Column" in result
-    assert "Type" in result
-    assert "|" in result
+    assert data["table"] == "users"
+    assert data["table_schema"] == "testdb"
+    assert data["schema"]["time_index"] == "ts"
+    assert data["schema"]["primary_keys"] == ["id"]
+    assert data["schema"]["columns"][0]["name"] == "id"
+    assert data["semantics"]["available"] is True
+    assert data["semantics"]["found"] is True
+    assert data["semantics"]["signal_type"] == "metric"
+    assert data["semantics"]["options"]["metric.type"] == "counter"
+    assert data["samples"]["included"] is True
+    assert data["samples"]["strategy"] == "latest_by_time_index"
+    assert data["samples"]["limit"] == 5
+    assert len(data["samples"]["rows"]) == 2
+    assert data["guidance"]
+
+
+@pytest.mark.asyncio
+async def test_describe_table_without_samples():
+    """Test describe_table can skip sample rows."""
+    result = await describe_table(table="users", include_samples=False)
+    data = json.loads(result)
+
+    assert data["samples"]["included"] is False
+    assert data["semantics"]["found"] is True
+
+
+@pytest.mark.asyncio
+async def test_describe_table_without_semantics():
+    """Test describe_table can skip table semantic metadata."""
+    result = await describe_table(table="users", include_semantics=False)
+    data = json.loads(result)
+
+    assert data["semantics"]["included"] is False
+    assert data["samples"]["included"] is True
+
+
+@pytest.mark.asyncio
+async def test_describe_table_without_semantic_row():
+    """Test describe_table when table_semantics exists but the table has no row."""
+    result = await describe_table(table="orders")
+    data = json.loads(result)
+
+    assert data["semantics"]["available"] is True
+    assert data["semantics"]["found"] is False
+    assert "No table semantic metadata was found" in data["guidance"][0]
+
+
+@pytest.mark.asyncio
+async def test_describe_table_semantics_unavailable():
+    """Test describe_table gracefully handles old versions without table_semantics."""
+
+    class Cursor:
+        def __init__(self):
+            self.query = ""
+            self._results = []
+
+        def execute(self, query, args=None):
+            self.query = query
+            if "information_schema.table_semantics" in query:
+                raise server.Error("table not found")
+            if "information_schema.columns" in query:
+                self._results = [
+                    ("id", "Int64", "TAG", "NO"),
+                    ("ts", "TimestampMillisecond", "TIMESTAMP", "NO"),
+                ]
+            elif "SELECT * FROM" in query:
+                self._results = [(1, "2024-01-01 00:00:00")]
+
+        def fetchall(self):
+            return self._results
+
+        def fetchone(self):
+            return None
+
+        @property
+        def description(self):
+            if "SELECT * FROM" in self.query:
+                return [("id", None), ("ts", None)]
+            return []
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            pass
+
+    class Connection:
+        def cursor(self):
+            return Cursor()
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            pass
+
+    server._state.pool = None
+    server._state.get_connection = lambda: Connection()
+
+    result = await describe_table(table="users")
+    data = json.loads(result)
+
+    assert data["schema"]["time_index"] == "ts"
+    assert data["semantics"]["available"] is False
+    assert data["semantics"]["found"] is False
+    assert data["samples"]["included"] is True
 
 
 @pytest.mark.asyncio
@@ -472,8 +576,18 @@ async def test_read_table_resource_invalid_name():
 async def test_describe_table_schema_qualified():
     """Test describe_table with schema.table format"""
     result = await describe_table(table="public.users")
-    assert "Column" in result
-    assert "Type" in result
+    data = json.loads(result)
+    assert data["table_schema"] == "public"
+    assert data["table_name"] == "users"
+    assert data["schema"]["time_index"] == "ts"
+
+
+@pytest.mark.asyncio
+async def test_describe_table_sample_limit_clamped():
+    """Test describe_table clamps sample limit."""
+    result = await describe_table(table="users", sample_limit=100)
+    data = json.loads(result)
+    assert data["samples"]["limit"] == 20
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Enhances describe_table to return a table profile with schema, semantic metadata, sample rows, and guidance. Gracefully handles GreptimeDB versions without information_schema.table_semantics.