### PR TITLE
feat: describe table profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ For Claude Desktop, add this to your config (`~/Library/Application Support/Clau
 | `execute_sql` | Execute SQL queries with format (csv/json/markdown) and limit options |
 | `execute_tql` | Execute TQL (PromQL-compatible) queries for time-series analysis |
 | `query_range` | Execute time-window aggregation queries with RANGE/ALIGN syntax |
-| `describe_table` | Get table schema including column names, types, and constraints |
+| `describe_table` | Inspect a table profile: schema, semantic metadata, latest sample rows, and query guidance |
 | `explain_query` | Analyze SQL or TQL query execution plans |
 | `health_check` | Check database connection status and server version |
 

--- a/conftest.py
+++ b/conftest.py
@@ -18,6 +18,29 @@ class MockCursor:
             self._results = [("users",), ("orders",)]
         elif "SHOW DATABASES" in self.query.upper():
             self._results = [("public",), ("greptime_private",)]
+        elif "INFORMATION_SCHEMA.COLUMNS" in self.query.upper():
+            self._results = [
+                ("id", "Int64", "TAG", "NO"),
+                ("name", "String", "FIELD", "YES"),
+                ("ts", "TimestampMillisecond", "TIMESTAMP", "NO"),
+            ]
+        elif "INFORMATION_SCHEMA.TABLE_SEMANTICS" in self.query.upper():
+            if args and args[1] == "users":
+                self._results = [
+                    (
+                        "greptime",
+                        args[0],
+                        args[1],
+                        1024,
+                        "metric",
+                        "opentelemetry",
+                        "",
+                        "declared",
+                        '{"metric.type":"counter","metric.unit":"By"}',
+                    )
+                ]
+            else:
+                self._results = []
         elif "DESCRIBE" in self.query.upper():
             self._results = [
                 ("id", "Int64", "", "PRI", "", ""),
@@ -46,6 +69,11 @@ class MockCursor:
         elif "GREPTIME_PRIVATE.PIPELINES" in self.query.upper():
             # Pipeline list query - returns empty by default
             self._results = []
+        elif "SELECT * FROM" in self.query.upper():
+            self._results = [
+                (1, "John", "2024-01-01 00:00:00"),
+                (2, "Jane", "2024-01-01 00:01:00"),
+            ]
         elif "SELECT" in self.query.upper():
             self._results = [(1, "John"), (2, "Jane")]
         else:
@@ -85,6 +113,25 @@ class MockCursor:
                 ("Default", None),
                 ("Semantic Type", None),
             ]
+        elif "INFORMATION_SCHEMA.COLUMNS" in self.query.upper():
+            return [
+                ("column_name", None),
+                ("data_type", None),
+                ("semantic_type", None),
+                ("is_nullable", None),
+            ]
+        elif "INFORMATION_SCHEMA.TABLE_SEMANTICS" in self.query.upper():
+            return [
+                ("table_catalog", None),
+                ("table_schema", None),
+                ("table_name", None),
+                ("table_id", None),
+                ("signal_type", None),
+                ("source", None),
+                ("pipeline", None),
+                ("metadata_quality", None),
+                ("semantic_options", None),
+            ]
         elif "VERSION()" in self.query.upper():
             return [("version()", None)]
         elif "TQL" in self.query.upper():
@@ -95,6 +142,8 @@ class MockCursor:
             return [("ts", None), ("host", None), ("avg_cpu", None)]
         elif "GREPTIME_PRIVATE.PIPELINES" in self.query.upper():
             return [("name", None), ("pipeline", None), ("version", None)]
+        elif "SELECT * FROM" in self.query.upper():
+            return [("id", None), ("name", None), ("ts", None)]
         elif "SELECT" in self.query.upper():
             return [("id", None), ("name", None)]
         return []

--- a/conftest.py
+++ b/conftest.py
@@ -20,10 +20,15 @@ class MockCursor:
             self._results = [("public",), ("greptime_private",)]
         elif "INFORMATION_SCHEMA.COLUMNS" in self.query.upper():
             self._results = [
-                ("id", "Int64", "TAG", "NO"),
-                ("name", "String", "FIELD", "YES"),
-                ("ts", "TimestampMillisecond", "TIMESTAMP", "NO"),
+                ("id", "Int64", "TAG", "NO", None),
+                ("name", "String", "FIELD", "YES", "user name"),
+                ("ts", "TimestampMillisecond", "TIMESTAMP", "NO", None),
             ]
+        elif "INFORMATION_SCHEMA.TABLES" in self.query.upper():
+            if args and args[1] == "users":
+                self._results = [("user activity table",)]
+            else:
+                self._results = []
         elif "INFORMATION_SCHEMA.TABLE_SEMANTICS" in self.query.upper():
             if args and args[1] == "users":
                 self._results = [
@@ -119,7 +124,10 @@ class MockCursor:
                 ("data_type", None),
                 ("semantic_type", None),
                 ("is_nullable", None),
+                ("column_comment", None),
             ]
+        elif "INFORMATION_SCHEMA.TABLES" in self.query.upper():
+            return [("table_comment", None)]
         elif "INFORMATION_SCHEMA.TABLE_SEMANTICS" in self.query.upper():
             return [
                 ("table_catalog", None),

--- a/docs/llm-instructions.md
+++ b/docs/llm-instructions.md
@@ -11,7 +11,7 @@ You have access to a GreptimeDB MCP server for querying and managing time-series
 - `execute_sql`: Run SQL queries (SELECT, SHOW, DESCRIBE only - read-only access)
 - `execute_tql`: Run PromQL-compatible time-series queries
 - `query_range`: Time-window aggregation with RANGE/ALIGN syntax
-- `describe_table`: Get table schema information
+- `describe_table`: Inspect a table profile: schema, semantic metadata, latest sample rows, and query guidance
 - `health_check`: Check database connection status
 - `explain_query`: Analyze query execution plans
 
@@ -44,7 +44,7 @@ Use these prompts for specialized tasks:
 ## Workflow Tips
 1. For log pipeline creation: Get log sample → use `pipeline_creator` prompt → generate YAML → `dryrun_pipeline` to verify → `create_pipeline`
 2. For dashboard creation: Prepare Perses JSON definition → `create_dashboard` → verify with `list_dashboards`
-3. For data analysis: `describe_table` first → understand schema → `execute_sql` or `execute_tql`
+3. For data analysis: `describe_table` first → understand schema, semantics, and sample rows → `execute_sql` or `execute_tql`
 4. For time-series: Prefer `query_range` for aggregations, `execute_tql` for PromQL patterns
 5. For schema design: collect workload, cardinality, and query patterns before proposing primary keys or indexes
 6. Always check `health_check` if queries fail unexpectedly

--- a/src/greptimedb_mcp_server/formatter.py
+++ b/src/greptimedb_mcp_server/formatter.py
@@ -33,7 +33,9 @@ def _format_json(columns: list, rows: list) -> str:
     for row in rows:
         row_dict = {col: _convert_value(row[i]) for i, col in enumerate(columns)}
         result.append(row_dict)
-    return json.dumps(result, ensure_ascii=False, indent=2)
+    # default=str keeps non-JSON-native values (Decimal, bytes, UUID) from
+    # raising TypeError; they fall back to their string form.
+    return json.dumps(result, ensure_ascii=False, indent=2, default=str)
 
 
 def _format_markdown(columns: list, rows: list) -> str:

--- a/src/greptimedb_mcp_server/server.py
+++ b/src/greptimedb_mcp_server/server.py
@@ -136,8 +136,8 @@ def _quote_identifier(name: str) -> str:
     return f"`{name.replace('`', '``')}`"
 
 
-def _quote_table_reference(table: str) -> str:
-    return ".".join(_quote_identifier(part) for part in table.split("."))
+def _quote_schema_table(table_schema: str, table_name: str) -> str:
+    return f"{_quote_identifier(table_schema)}.{_quote_identifier(table_name)}"
 
 
 def _normalize_nullable(value) -> bool | None:
@@ -256,14 +256,18 @@ def _fetch_table_semantics(cursor, table_schema: str, table_name: str) -> dict:
 
 
 def _fetch_table_samples(
-    cursor, state, table: str, schema: dict, sample_limit: int
+    cursor, state, table_schema: str, table_name: str, schema: dict, sample_limit: int
 ) -> dict:
-    """Read a small sample, preferring the newest rows when a time index exists."""
+    """Read a small sample, preferring the newest rows when a time index exists.
+
+    The sample query targets the resolved schema.table, ignoring any catalog
+    segment, to stay consistent with how schema/semantics are resolved.
+    """
     if sample_limit == 0:
         return {"included": True, "limit": 0, "columns": [], "rows": []}
 
     try:
-        quoted_table = _quote_table_reference(table)
+        quoted_table = _quote_schema_table(table_schema, table_name)
         time_index = schema.get("time_index")
         if time_index:
             strategy = "latest_by_time_index"
@@ -592,7 +596,9 @@ async def describe_table(
                     else {"included": False}
                 )
                 samples = (
-                    _fetch_table_samples(cursor, state, table, schema, sample_limit)
+                    _fetch_table_samples(
+                        cursor, state, table_schema, table_name, schema, sample_limit
+                    )
                     if include_samples
                     else {"included": False}
                 )
@@ -611,7 +617,17 @@ async def describe_table(
         return await asyncio.to_thread(_sync_describe)
     except Error as e:
         logger.error(f"Error describing table '{table}': {e}")
-        return f"Error: {str(e)}"
+        return json.dumps(
+            {
+                "table": table,
+                "table_schema": table_schema,
+                "table_name": table_name,
+                "error": f"Error describing table: {str(e)}",
+            },
+            ensure_ascii=False,
+            indent=2,
+            default=str,
+        )
 
 
 @mcp.tool()

--- a/src/greptimedb_mcp_server/server.py
+++ b/src/greptimedb_mcp_server/server.py
@@ -151,11 +151,19 @@ def _normalize_nullable(value) -> bool | None:
     return None
 
 
+def _clean_comment(value) -> str | None:
+    """Normalize a comment to a non-empty trimmed string, or None."""
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
 def _fetch_table_schema(cursor, table_schema: str, table_name: str) -> dict:
     """Read column-level schema, deriving the time index and primary keys."""
     cursor.execute(
         """
-        SELECT column_name, data_type, semantic_type, is_nullable
+        SELECT column_name, data_type, semantic_type, is_nullable, column_comment
         FROM information_schema.columns
         WHERE table_schema = %s AND table_name = %s
         ORDER BY ordinal_position
@@ -168,24 +176,43 @@ def _fetch_table_schema(cursor, table_schema: str, table_name: str) -> dict:
     primary_keys = []
     for row in rows:
         column_name, data_type, semantic_type, is_nullable = row[:4]
+        column_comment = row[4] if len(row) > 4 else None
         semantic_type_text = str(semantic_type).upper() if semantic_type else ""
         if semantic_type_text == "TIMESTAMP":
             time_index = column_name
         elif semantic_type_text in {"TAG", "PRIMARY KEY", "PRIMARY_KEY"}:
             primary_keys.append(column_name)
-        columns.append(
-            {
-                "name": column_name,
-                "data_type": data_type,
-                "semantic_type": semantic_type,
-                "nullable": _normalize_nullable(is_nullable),
-            }
-        )
+        column = {
+            "name": column_name,
+            "data_type": data_type,
+            "semantic_type": semantic_type,
+            "nullable": _normalize_nullable(is_nullable),
+        }
+        comment = _clean_comment(column_comment)
+        if comment:
+            column["comment"] = comment
+        columns.append(column)
     return {
         "columns": columns,
         "time_index": time_index,
         "primary_keys": primary_keys,
     }
+
+
+def _fetch_table_comment(cursor, table_schema: str, table_name: str) -> str | None:
+    """Read the table-level comment, returning None when absent or empty."""
+    cursor.execute(
+        """
+        SELECT table_comment
+        FROM information_schema.tables
+        WHERE table_schema = %s AND table_name = %s
+        """,
+        (table_schema, table_name),
+    )
+    rows = cursor.fetchall()
+    if rows:
+        return _clean_comment(rows[0][0])
+    return None
 
 
 def _fetch_table_semantics(cursor, table_schema: str, table_name: str) -> dict:
@@ -590,6 +617,7 @@ async def describe_table(
                         indent=2,
                         default=str,
                     )
+                table_comment = _fetch_table_comment(cursor, table_schema, table_name)
                 semantics = (
                     _fetch_table_semantics(cursor, table_schema, table_name)
                     if include_semantics
@@ -606,6 +634,7 @@ async def describe_table(
                     "table": table,
                     "table_schema": table_schema,
                     "table_name": table_name,
+                    **({"table_comment": table_comment} if table_comment else {}),
                     "schema": schema,
                     "semantics": semantics,
                     "samples": samples,

--- a/src/greptimedb_mcp_server/server.py
+++ b/src/greptimedb_mcp_server/server.py
@@ -44,6 +44,7 @@ from mysql.connector.pooling import MySQLConnectionPool
 RES_PREFIX = "greptime://"
 RESULTS_LIMIT = 100
 MAX_QUERY_LIMIT = 10000
+MAX_SAMPLE_LIMIT = 20
 
 # Configure logging
 logging.basicConfig(
@@ -114,6 +115,32 @@ def get_state() -> AppState:
     if _state is None:
         raise RuntimeError("Application state not initialized")
     return _state
+
+
+def _split_table_reference(table: str, default_schema: str) -> tuple[str, str]:
+    parts = table.split(".", 1)
+    if len(parts) == 2:
+        return parts[0], parts[1]
+    return default_schema, table
+
+
+def _quote_identifier(name: str) -> str:
+    return f"`{name.replace('`', '``')}`"
+
+
+def _quote_table_reference(table: str) -> str:
+    return ".".join(_quote_identifier(part) for part in table.split("."))
+
+
+def _normalize_nullable(value) -> bool | None:
+    if value is None:
+        return None
+    text = str(value).upper()
+    if text in {"YES", "Y", "TRUE", "1"}:
+        return True
+    if text in {"NO", "N", "FALSE", "0"}:
+        return False
+    return None
 
 
 @asynccontextmanager
@@ -295,24 +322,243 @@ async def execute_sql(
 @mcp.tool()
 async def describe_table(
     table: Annotated[str, "Table name to describe (supports schema.table format)"],
+    include_semantics: Annotated[
+        bool,
+        "Include table semantic metadata from information_schema.table_semantics",
+    ] = True,
+    include_samples: Annotated[
+        bool,
+        "Include a small sample of table rows for context",
+    ] = True,
+    sample_limit: Annotated[
+        int,
+        f"Maximum sample rows to return (0-{MAX_SAMPLE_LIMIT}, default: 5)",
+    ] = 5,
 ) -> str:
-    """Get table schema information including column names, types, and constraints."""
+    """Get a table profile: schema, semantic metadata, sample rows, and guidance."""
     state = get_state()
     table = validate_table_name(table)
+    sample_limit = max(0, min(sample_limit, MAX_SAMPLE_LIMIT))
+    table_schema, table_name = _split_table_reference(
+        table, state.db_config["database"]
+    )
+
+    def _fetch_schema(cursor) -> dict:
+        cursor.execute(
+            """
+            SELECT column_name, data_type, semantic_type, is_nullable
+            FROM information_schema.columns
+            WHERE table_schema = %s AND table_name = %s
+            ORDER BY ordinal_position
+            """,
+            (table_schema, table_name),
+        )
+        rows = cursor.fetchall()
+        columns = []
+        time_index = None
+        primary_keys = []
+        for row in rows:
+            column_name, data_type, semantic_type, is_nullable = row[:4]
+            semantic_type_text = str(semantic_type).upper() if semantic_type else ""
+            if semantic_type_text == "TIMESTAMP":
+                time_index = column_name
+            elif semantic_type_text in {"TAG", "PRIMARY KEY", "PRIMARY_KEY"}:
+                primary_keys.append(column_name)
+            columns.append(
+                {
+                    "name": column_name,
+                    "data_type": data_type,
+                    "semantic_type": semantic_type,
+                    "nullable": _normalize_nullable(is_nullable),
+                }
+            )
+        return {
+            "columns": columns,
+            "time_index": time_index,
+            "primary_keys": primary_keys,
+        }
+
+    def _fetch_semantics(cursor) -> dict:
+        if not include_semantics:
+            return {"included": False}
+        try:
+            cursor.execute(
+                """
+                SELECT table_catalog, table_schema, table_name, table_id,
+                       signal_type, source, pipeline, metadata_quality,
+                       semantic_options
+                FROM information_schema.table_semantics
+                WHERE table_schema = %s AND table_name = %s
+                """,
+                (table_schema, table_name),
+            )
+            # Unbuffered cursors require the result set to be fully consumed before
+            # the same cursor runs the next query (see drain pattern above). The
+            # WHERE clause matches at most one row, so fetchall() is both correct
+            # and drains the cursor.
+            rows = cursor.fetchall()
+            row = rows[0] if rows else None
+        except Error as e:
+            return {
+                "included": True,
+                "available": False,
+                "found": False,
+                "error": str(e),
+            }
+
+        if not row:
+            return {"included": True, "available": True, "found": False}
+
+        semantic_options = row[8]
+        options = {}
+        raw_options = None
+        parse_error = None
+        if semantic_options:
+            try:
+                options = json.loads(semantic_options)
+            except (TypeError, json.JSONDecodeError) as e:
+                raw_options = semantic_options
+                parse_error = str(e)
+
+        result = {
+            "included": True,
+            "available": True,
+            "found": True,
+            "table_catalog": row[0],
+            "table_schema": row[1],
+            "table_name": row[2],
+            "table_id": row[3],
+            "signal_type": row[4],
+            "source": row[5],
+            "pipeline": row[6],
+            "metadata_quality": row[7],
+            "options": options,
+        }
+        if raw_options is not None:
+            result["raw_options"] = raw_options
+            result["options_parse_error"] = parse_error
+        return result
+
+    def _fetch_samples(cursor, schema: dict) -> dict:
+        if not include_samples:
+            return {"included": False}
+        if sample_limit == 0:
+            return {"included": True, "limit": 0, "columns": [], "rows": []}
+
+        try:
+            quoted_table = _quote_table_reference(table)
+            time_index = schema.get("time_index")
+            if time_index:
+                strategy = "latest_by_time_index"
+                query = (
+                    f"SELECT * FROM {quoted_table} "
+                    f"ORDER BY {_quote_identifier(time_index)} DESC LIMIT %s"
+                )
+            else:
+                strategy = "plain_limit"
+                query = f"SELECT * FROM {quoted_table} LIMIT %s"
+
+            cursor.execute(query, (sample_limit,))
+            columns = [desc[0] for desc in cursor.description]
+            rows = cursor.fetchall()
+            formatted = format_results(
+                columns,
+                rows,
+                "json",
+                mask_enabled=state.mask_enabled,
+                mask_patterns=state.mask_patterns,
+            )
+            return {
+                "included": True,
+                "strategy": strategy,
+                "limit": sample_limit,
+                "columns": columns,
+                "rows": json.loads(formatted),
+            }
+        except Error as e:
+            return {
+                "included": True,
+                "limit": sample_limit,
+                "columns": [],
+                "rows": [],
+                "error": str(e),
+            }
+
+    def _build_guidance(schema: dict, semantics: dict, samples: dict) -> list[str]:
+        guidance = []
+        if semantics.get("included") and not semantics.get("available", True):
+            guidance.append(
+                "Table semantic metadata is unavailable. The connected GreptimeDB "
+                "version may not support information_schema.table_semantics."
+            )
+        elif semantics.get("included") and not semantics.get("found"):
+            guidance.append(
+                "No table semantic metadata was found. Treat signal type and "
+                "query pattern as schema/sample-based inference."
+            )
+
+        signal_type = semantics.get("signal_type")
+        options = semantics.get("options") or {}
+        metric_type = options.get("metric.type")
+        metadata_quality = semantics.get("metadata_quality")
+
+        if signal_type == "metric":
+            if metric_type == "counter":
+                guidance.append(
+                    "This table is a counter metric. Prefer rate or increase "
+                    "queries for trend analysis."
+                )
+            elif metric_type == "gauge":
+                guidance.append(
+                    "This table is a gauge metric. Prefer absolute value, avg, "
+                    "min, max, or percentile analysis."
+                )
+            elif metric_type == "histogram":
+                guidance.append(
+                    "This table is a histogram metric. Prefer bucket/count/sum "
+                    "based percentile analysis."
+                )
+            if metadata_quality == "inferred":
+                guidance.append(
+                    "Metric type was inferred from naming. Re-check the query "
+                    "choice if the metric name is non-standard."
+                )
+        elif signal_type == "trace":
+            guidance.append(
+                "This table represents traces. Prefer latency, error span, and "
+                "service-level aggregation queries."
+            )
+        elif signal_type == "log":
+            guidance.append(
+                "This table represents logs. Prefer full-text search plus "
+                "severity, time, and service aggregations."
+            )
+
+        if (
+            samples.get("included")
+            and samples.get("strategy") == "latest_by_time_index"
+        ):
+            guidance.append(
+                f"Sample rows are ordered by time index {schema.get('time_index')} descending."
+            )
+        return guidance
 
     def _sync_describe():
         with state.get_connection() as conn:
             with conn.cursor() as cursor:
-                cursor.execute(f"DESCRIBE {table}")
-                columns = [desc[0] for desc in cursor.description]
-                rows = cursor.fetchall()
-                return format_results(
-                    columns,
-                    rows,
-                    "markdown",
-                    mask_enabled=state.mask_enabled,
-                    mask_patterns=state.mask_patterns,
-                )
+                schema = _fetch_schema(cursor)
+                semantics = _fetch_semantics(cursor)
+                samples = _fetch_samples(cursor, schema)
+                result = {
+                    "table": table,
+                    "table_schema": table_schema,
+                    "table_name": table_name,
+                    "schema": schema,
+                    "semantics": semantics,
+                    "samples": samples,
+                    "guidance": _build_guidance(schema, semantics, samples),
+                }
+                return json.dumps(result, ensure_ascii=False, indent=2, default=str)
 
     try:
         return await asyncio.to_thread(_sync_describe)

--- a/src/greptimedb_mcp_server/server.py
+++ b/src/greptimedb_mcp_server/server.py
@@ -118,10 +118,18 @@ def get_state() -> AppState:
 
 
 def _split_table_reference(table: str, default_schema: str) -> tuple[str, str]:
-    parts = table.split(".", 1)
-    if len(parts) == 2:
-        return parts[0], parts[1]
-    return default_schema, table
+    """Split a possibly-qualified table reference into (schema, table).
+
+    Mirrors GreptimeDB's table_idents_to_full_name: the table name is always the
+    last segment, the schema the second-to-last. A leading catalog segment
+    (catalog.schema.table) is accepted for compatibility but ignored, since
+    information_schema is scoped to the connected catalog. Input is restricted to
+    at most three unquoted segments by validate_table_name.
+    """
+    parts = table.split(".")
+    if len(parts) == 1:
+        return default_schema, parts[0]
+    return parts[-2], parts[-1]
 
 
 def _quote_identifier(name: str) -> str:
@@ -214,10 +222,18 @@ def _fetch_table_semantics(cursor, table_schema: str, table_name: str) -> dict:
     parse_error = None
     if semantic_options:
         try:
-            options = json.loads(semantic_options)
+            parsed = json.loads(semantic_options)
         except (TypeError, json.JSONDecodeError) as e:
             raw_options = semantic_options
             parse_error = str(e)
+        else:
+            # Guidance treats options as a key/value map; a non-object payload
+            # would crash _build_table_guidance, so keep it as raw instead.
+            if isinstance(parsed, dict):
+                options = parsed
+            else:
+                raw_options = semantic_options
+                parse_error = "semantic_options is not a JSON object"
 
     result = {
         "included": True,
@@ -524,7 +540,11 @@ async def execute_sql(
 
 @mcp.tool()
 async def describe_table(
-    table: Annotated[str, "Table name to describe (supports schema.table format)"],
+    table: Annotated[
+        str,
+        "Table name to describe (supports table, schema.table, or "
+        "catalog.schema.table format)",
+    ],
     include_semantics: Annotated[
         bool,
         "Include table semantic metadata from information_schema.table_semantics",

--- a/src/greptimedb_mcp_server/server.py
+++ b/src/greptimedb_mcp_server/server.py
@@ -143,6 +143,209 @@ def _normalize_nullable(value) -> bool | None:
     return None
 
 
+def _fetch_table_schema(cursor, table_schema: str, table_name: str) -> dict:
+    """Read column-level schema, deriving the time index and primary keys."""
+    cursor.execute(
+        """
+        SELECT column_name, data_type, semantic_type, is_nullable
+        FROM information_schema.columns
+        WHERE table_schema = %s AND table_name = %s
+        ORDER BY ordinal_position
+        """,
+        (table_schema, table_name),
+    )
+    rows = cursor.fetchall()
+    columns = []
+    time_index = None
+    primary_keys = []
+    for row in rows:
+        column_name, data_type, semantic_type, is_nullable = row[:4]
+        semantic_type_text = str(semantic_type).upper() if semantic_type else ""
+        if semantic_type_text == "TIMESTAMP":
+            time_index = column_name
+        elif semantic_type_text in {"TAG", "PRIMARY KEY", "PRIMARY_KEY"}:
+            primary_keys.append(column_name)
+        columns.append(
+            {
+                "name": column_name,
+                "data_type": data_type,
+                "semantic_type": semantic_type,
+                "nullable": _normalize_nullable(is_nullable),
+            }
+        )
+    return {
+        "columns": columns,
+        "time_index": time_index,
+        "primary_keys": primary_keys,
+    }
+
+
+def _fetch_table_semantics(cursor, table_schema: str, table_name: str) -> dict:
+    """Read the experimental table_semantics view, degrading if it is absent."""
+    try:
+        cursor.execute(
+            """
+            SELECT table_catalog, table_schema, table_name, table_id,
+                   signal_type, source, pipeline, metadata_quality,
+                   semantic_options
+            FROM information_schema.table_semantics
+            WHERE table_schema = %s AND table_name = %s
+            """,
+            (table_schema, table_name),
+        )
+        # fetchall() drains the unbuffered cursor before the next query runs;
+        # the WHERE clause matches at most one row.
+        rows = cursor.fetchall()
+        row = rows[0] if rows else None
+    except Error as e:
+        return {
+            "included": True,
+            "available": False,
+            "found": False,
+            "error": str(e),
+        }
+
+    if not row:
+        return {"included": True, "available": True, "found": False}
+
+    semantic_options = row[8]
+    options = {}
+    raw_options = None
+    parse_error = None
+    if semantic_options:
+        try:
+            options = json.loads(semantic_options)
+        except (TypeError, json.JSONDecodeError) as e:
+            raw_options = semantic_options
+            parse_error = str(e)
+
+    result = {
+        "included": True,
+        "available": True,
+        "found": True,
+        "table_catalog": row[0],
+        "table_schema": row[1],
+        "table_name": row[2],
+        "table_id": row[3],
+        "signal_type": row[4],
+        "source": row[5],
+        "pipeline": row[6],
+        "metadata_quality": row[7],
+        "options": options,
+    }
+    if raw_options is not None:
+        result["raw_options"] = raw_options
+        result["options_parse_error"] = parse_error
+    return result
+
+
+def _fetch_table_samples(
+    cursor, state, table: str, schema: dict, sample_limit: int
+) -> dict:
+    """Read a small sample, preferring the newest rows when a time index exists."""
+    if sample_limit == 0:
+        return {"included": True, "limit": 0, "columns": [], "rows": []}
+
+    try:
+        quoted_table = _quote_table_reference(table)
+        time_index = schema.get("time_index")
+        if time_index:
+            strategy = "latest_by_time_index"
+            query = (
+                f"SELECT * FROM {quoted_table} "
+                f"ORDER BY {_quote_identifier(time_index)} DESC LIMIT %s"
+            )
+        else:
+            strategy = "plain_limit"
+            query = f"SELECT * FROM {quoted_table} LIMIT %s"
+
+        cursor.execute(query, (sample_limit,))
+        columns = [desc[0] for desc in cursor.description]
+        rows = cursor.fetchall()
+        formatted = format_results(
+            columns,
+            rows,
+            "json",
+            mask_enabled=state.mask_enabled,
+            mask_patterns=state.mask_patterns,
+        )
+        return {
+            "included": True,
+            "strategy": strategy,
+            "limit": sample_limit,
+            "columns": columns,
+            "rows": json.loads(formatted),
+        }
+    except Exception as e:
+        # Best-effort sample: a failed read (missing table, unsupported value
+        # type) must not sink the rest of the profile.
+        return {
+            "included": True,
+            "limit": sample_limit,
+            "columns": [],
+            "rows": [],
+            "error": str(e),
+        }
+
+
+def _build_table_guidance(schema: dict, semantics: dict, samples: dict) -> list[str]:
+    """Derive query hints from signal type, metric kind, and sample ordering."""
+    guidance = []
+    if semantics.get("included") and not semantics.get("available", True):
+        guidance.append(
+            "Table semantic metadata is unavailable. The connected GreptimeDB "
+            "version may not support information_schema.table_semantics."
+        )
+    elif semantics.get("included") and not semantics.get("found"):
+        guidance.append(
+            "No table semantic metadata was found. Treat signal type and "
+            "query pattern as schema/sample-based inference."
+        )
+
+    signal_type = semantics.get("signal_type")
+    options = semantics.get("options") or {}
+    metric_type = options.get("metric.type")
+    metadata_quality = semantics.get("metadata_quality")
+
+    if signal_type == "metric":
+        if metric_type == "counter":
+            guidance.append(
+                "This table is a counter metric. Prefer rate or increase "
+                "queries for trend analysis."
+            )
+        elif metric_type == "gauge":
+            guidance.append(
+                "This table is a gauge metric. Prefer absolute value, avg, "
+                "min, max, or percentile analysis."
+            )
+        elif metric_type == "histogram":
+            guidance.append(
+                "This table is a histogram metric. Prefer bucket/count/sum "
+                "based percentile analysis."
+            )
+        if metadata_quality == "inferred":
+            guidance.append(
+                "Metric type was inferred from naming. Re-check the query "
+                "choice if the metric name is non-standard."
+            )
+    elif signal_type == "trace":
+        guidance.append(
+            "This table represents traces. Prefer latency, error span, and "
+            "service-level aggregation queries."
+        )
+    elif signal_type == "log":
+        guidance.append(
+            "This table represents logs. Prefer full-text search plus "
+            "severity, time, and service aggregations."
+        )
+
+    if samples.get("included") and samples.get("strategy") == "latest_by_time_index":
+        guidance.append(
+            f"Sample rows are ordered by time index {schema.get('time_index')} descending."
+        )
+    return guidance
+
+
 @asynccontextmanager
 async def lifespan(mcp: FastMCP):
     """Initialize application state on startup."""
@@ -343,212 +546,36 @@ async def describe_table(
         table, state.db_config["database"]
     )
 
-    def _fetch_schema(cursor) -> dict:
-        cursor.execute(
-            """
-            SELECT column_name, data_type, semantic_type, is_nullable
-            FROM information_schema.columns
-            WHERE table_schema = %s AND table_name = %s
-            ORDER BY ordinal_position
-            """,
-            (table_schema, table_name),
-        )
-        rows = cursor.fetchall()
-        columns = []
-        time_index = None
-        primary_keys = []
-        for row in rows:
-            column_name, data_type, semantic_type, is_nullable = row[:4]
-            semantic_type_text = str(semantic_type).upper() if semantic_type else ""
-            if semantic_type_text == "TIMESTAMP":
-                time_index = column_name
-            elif semantic_type_text in {"TAG", "PRIMARY KEY", "PRIMARY_KEY"}:
-                primary_keys.append(column_name)
-            columns.append(
-                {
-                    "name": column_name,
-                    "data_type": data_type,
-                    "semantic_type": semantic_type,
-                    "nullable": _normalize_nullable(is_nullable),
-                }
-            )
-        return {
-            "columns": columns,
-            "time_index": time_index,
-            "primary_keys": primary_keys,
-        }
-
-    def _fetch_semantics(cursor) -> dict:
-        if not include_semantics:
-            return {"included": False}
-        try:
-            cursor.execute(
-                """
-                SELECT table_catalog, table_schema, table_name, table_id,
-                       signal_type, source, pipeline, metadata_quality,
-                       semantic_options
-                FROM information_schema.table_semantics
-                WHERE table_schema = %s AND table_name = %s
-                """,
-                (table_schema, table_name),
-            )
-            # Unbuffered cursors require the result set to be fully consumed before
-            # the same cursor runs the next query (see drain pattern above). The
-            # WHERE clause matches at most one row, so fetchall() is both correct
-            # and drains the cursor.
-            rows = cursor.fetchall()
-            row = rows[0] if rows else None
-        except Error as e:
-            return {
-                "included": True,
-                "available": False,
-                "found": False,
-                "error": str(e),
-            }
-
-        if not row:
-            return {"included": True, "available": True, "found": False}
-
-        semantic_options = row[8]
-        options = {}
-        raw_options = None
-        parse_error = None
-        if semantic_options:
-            try:
-                options = json.loads(semantic_options)
-            except (TypeError, json.JSONDecodeError) as e:
-                raw_options = semantic_options
-                parse_error = str(e)
-
-        result = {
-            "included": True,
-            "available": True,
-            "found": True,
-            "table_catalog": row[0],
-            "table_schema": row[1],
-            "table_name": row[2],
-            "table_id": row[3],
-            "signal_type": row[4],
-            "source": row[5],
-            "pipeline": row[6],
-            "metadata_quality": row[7],
-            "options": options,
-        }
-        if raw_options is not None:
-            result["raw_options"] = raw_options
-            result["options_parse_error"] = parse_error
-        return result
-
-    def _fetch_samples(cursor, schema: dict) -> dict:
-        if not include_samples:
-            return {"included": False}
-        if sample_limit == 0:
-            return {"included": True, "limit": 0, "columns": [], "rows": []}
-
-        try:
-            quoted_table = _quote_table_reference(table)
-            time_index = schema.get("time_index")
-            if time_index:
-                strategy = "latest_by_time_index"
-                query = (
-                    f"SELECT * FROM {quoted_table} "
-                    f"ORDER BY {_quote_identifier(time_index)} DESC LIMIT %s"
-                )
-            else:
-                strategy = "plain_limit"
-                query = f"SELECT * FROM {quoted_table} LIMIT %s"
-
-            cursor.execute(query, (sample_limit,))
-            columns = [desc[0] for desc in cursor.description]
-            rows = cursor.fetchall()
-            formatted = format_results(
-                columns,
-                rows,
-                "json",
-                mask_enabled=state.mask_enabled,
-                mask_patterns=state.mask_patterns,
-            )
-            return {
-                "included": True,
-                "strategy": strategy,
-                "limit": sample_limit,
-                "columns": columns,
-                "rows": json.loads(formatted),
-            }
-        except Error as e:
-            return {
-                "included": True,
-                "limit": sample_limit,
-                "columns": [],
-                "rows": [],
-                "error": str(e),
-            }
-
-    def _build_guidance(schema: dict, semantics: dict, samples: dict) -> list[str]:
-        guidance = []
-        if semantics.get("included") and not semantics.get("available", True):
-            guidance.append(
-                "Table semantic metadata is unavailable. The connected GreptimeDB "
-                "version may not support information_schema.table_semantics."
-            )
-        elif semantics.get("included") and not semantics.get("found"):
-            guidance.append(
-                "No table semantic metadata was found. Treat signal type and "
-                "query pattern as schema/sample-based inference."
-            )
-
-        signal_type = semantics.get("signal_type")
-        options = semantics.get("options") or {}
-        metric_type = options.get("metric.type")
-        metadata_quality = semantics.get("metadata_quality")
-
-        if signal_type == "metric":
-            if metric_type == "counter":
-                guidance.append(
-                    "This table is a counter metric. Prefer rate or increase "
-                    "queries for trend analysis."
-                )
-            elif metric_type == "gauge":
-                guidance.append(
-                    "This table is a gauge metric. Prefer absolute value, avg, "
-                    "min, max, or percentile analysis."
-                )
-            elif metric_type == "histogram":
-                guidance.append(
-                    "This table is a histogram metric. Prefer bucket/count/sum "
-                    "based percentile analysis."
-                )
-            if metadata_quality == "inferred":
-                guidance.append(
-                    "Metric type was inferred from naming. Re-check the query "
-                    "choice if the metric name is non-standard."
-                )
-        elif signal_type == "trace":
-            guidance.append(
-                "This table represents traces. Prefer latency, error span, and "
-                "service-level aggregation queries."
-            )
-        elif signal_type == "log":
-            guidance.append(
-                "This table represents logs. Prefer full-text search plus "
-                "severity, time, and service aggregations."
-            )
-
-        if (
-            samples.get("included")
-            and samples.get("strategy") == "latest_by_time_index"
-        ):
-            guidance.append(
-                f"Sample rows are ordered by time index {schema.get('time_index')} descending."
-            )
-        return guidance
-
     def _sync_describe():
         with state.get_connection() as conn:
             with conn.cursor() as cursor:
-                schema = _fetch_schema(cursor)
-                semantics = _fetch_semantics(cursor)
-                samples = _fetch_samples(cursor, schema)
+                schema = _fetch_table_schema(cursor, table_schema, table_name)
+                if not schema["columns"]:
+                    return json.dumps(
+                        {
+                            "table": table,
+                            "table_schema": table_schema,
+                            "table_name": table_name,
+                            "schema": schema,
+                            "error": (
+                                f"Table '{table}' not found or has no visible "
+                                "columns."
+                            ),
+                        },
+                        ensure_ascii=False,
+                        indent=2,
+                        default=str,
+                    )
+                semantics = (
+                    _fetch_table_semantics(cursor, table_schema, table_name)
+                    if include_semantics
+                    else {"included": False}
+                )
+                samples = (
+                    _fetch_table_samples(cursor, state, table, schema, sample_limit)
+                    if include_samples
+                    else {"included": False}
+                )
                 result = {
                     "table": table,
                     "table_schema": table_schema,
@@ -556,7 +583,7 @@ async def describe_table(
                     "schema": schema,
                     "semantics": semantics,
                     "samples": samples,
-                    "guidance": _build_guidance(schema, semantics, samples),
+                    "guidance": _build_table_guidance(schema, semantics, samples),
                 }
                 return json.dumps(result, ensure_ascii=False, indent=2, default=str)
 

--- a/src/greptimedb_mcp_server/templates/metrics_analysis/template.md
+++ b/src/greptimedb_mcp_server/templates/metrics_analysis/template.md
@@ -7,13 +7,14 @@ Analyze metrics data from GreptimeDB for topic: {{ topic }}
 ## Available Tools
 
 - `execute_sql` - Execute SQL queries (MySQL syntax)
-- `describe_table` - Get table schema
+- `describe_table` - Inspect table profile: schema, semantics, and sample rows
+- `execute_tql` - Execute PromQL-compatible queries
 - `query_range` - Time-window aggregations with RANGE syntax
 
 ## Guidelines
 
 1. Always filter by time range for time-series queries
-2. Use `DESCRIBE table_name` to explore schema first
+2. Use `describe_table` first to inspect schema, semantic metadata, and sample rows
 3. Use aggregation functions: avg, max, min, sum, count, stddev
 4. Results are read-only; write operations are blocked
 5. Verify the actual time index and value column names before running examples
@@ -24,8 +25,8 @@ Analyze metrics data from GreptimeDB for topic: {{ topic }}
 -- List tables
 SHOW TABLES;
 
--- Get schema
-DESCRIBE your_table;
+-- Get table profile with schema, semantics, and sample rows
+-- Use describe_table(table="your_table")
 
 -- Recent data sample
 SELECT * FROM your_table

--- a/src/greptimedb_mcp_server/templates/table_operation/template.md
+++ b/src/greptimedb_mcp_server/templates/table_operation/template.md
@@ -1,8 +1,8 @@
 # Table Diagnostics: {{ table }}
 
 {% set _parts = table.split('.') %}
-{% set schema = _parts[0] if _parts | length > 1 else '' %}
-{% set tbl = _parts[1] if _parts | length > 1 else table %}
+{% set tbl = _parts[-1] %}
+{% set schema = _parts[-2] if _parts | length > 1 else '' %}
 Analyze table structure, region health, storage metadata, and cluster state.
 For slow query analysis, use the `query_performance_tuning` prompt instead.
 

--- a/src/greptimedb_mcp_server/templates/table_operation/template.md
+++ b/src/greptimedb_mcp_server/templates/table_operation/template.md
@@ -26,7 +26,7 @@ qualified name directly.
 SHOW CREATE TABLE {{ table }};
 
 -- Table semantic metadata, if supported by this GreptimeDB version
-SELECT table_schema, table_name, signal_type, source, pipeline, metadata_quality, semantic_options
+SELECT *
 FROM information_schema.table_semantics
 WHERE table_name = '{{ tbl }}'{% if schema %} AND table_schema = '{{ schema }}'{% endif %};
 

--- a/src/greptimedb_mcp_server/templates/table_operation/template.md
+++ b/src/greptimedb_mcp_server/templates/table_operation/template.md
@@ -12,17 +12,23 @@ qualified name directly.
 
 ## Available Tools
 
-- `describe_table` - Get table schema
+- `describe_table` - Inspect table profile: schema, semantic metadata, sample rows
+- `explain_query` - Analyze query execution plan (set `analyze=true` for runtime stats)
 - `execute_sql` - Run diagnostic SQL queries
 
 ## Schema Analysis
 
 ```sql
--- Table structure
-DESCRIBE {{ table }};
+-- Table profile
+-- Use describe_table(table="{{ table }}") for schema, semantics, and sample rows.
 
 -- Full DDL
 SHOW CREATE TABLE {{ table }};
+
+-- Table semantic metadata, if supported by this GreptimeDB version
+SELECT table_schema, table_name, signal_type, source, pipeline, metadata_quality, semantic_options
+FROM information_schema.table_semantics
+WHERE table_name = '{{ tbl }}'{% if schema %} AND table_schema = '{{ schema }}'{% endif %};
 
 -- Column details
 SELECT column_name, data_type, semantic_type, is_nullable

--- a/src/greptimedb_mcp_server/utils.py
+++ b/src/greptimedb_mcp_server/utils.py
@@ -116,17 +116,27 @@ def render_prompt_template(template: str, context: dict[str, Any]) -> str:
 
 
 # Validation patterns
-TABLE_NAME_PATTERN = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*(\.[a-zA-Z_][a-zA-Z0-9_]*)?$")
+TABLE_NAME_PATTERN = re.compile(
+    r"^[a-zA-Z_][a-zA-Z0-9_]*(\.[a-zA-Z_][a-zA-Z0-9_]*){0,2}$"
+)
 DURATION_PATTERN = re.compile(r"^(\d+)(ms|s|m|h|d|w|y)$")
 FILL_PATTERN = re.compile(r"^(NULL|PREV|LINEAR|(-?\d+(\.\d+)?))$", re.IGNORECASE)
 
 
 def validate_table_name(table: str) -> str:
-    """Validate table name format. Supports schema.table format."""
+    """Validate table name format.
+
+    Accepts unquoted GreptimeDB-style names with up to three segments:
+    'table', 'schema.table', or 'catalog.schema.table'. Quoted identifiers
+    (backticks) are not supported.
+    """
     if not table:
         raise ValueError("Table name is required")
     if not TABLE_NAME_PATTERN.match(table):
-        raise ValueError("Invalid table name: must be 'table' or 'schema.table' format")
+        raise ValueError(
+            "Invalid table name: must be 'table', 'schema.table', or "
+            "'catalog.schema.table' format (unquoted identifiers only)"
+        )
     return table
 
 

--- a/tests/test_http_transport.py
+++ b/tests/test_http_transport.py
@@ -34,6 +34,18 @@ def mock_db_connection():
         yield mock_connect
 
 
+@pytest.fixture(autouse=True)
+def reset_sse_app_status():
+    """Reset sse-starlette global state between pytest-asyncio event loops."""
+    from sse_starlette.sse import AppStatus
+
+    AppStatus.should_exit = False
+    AppStatus.should_exit_event = None
+    yield
+    AppStatus.should_exit = False
+    AppStatus.should_exit_event = None
+
+
 class TestStreamableHttpTransport:
     """Tests for streamable-http transport mode."""
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -173,12 +173,116 @@ async def test_execute_sql_union_allowed():
 
 @pytest.mark.asyncio
 async def test_describe_table():
-    """Test describe_table tool"""
+    """Test describe_table tool returns schema, semantics, samples, and guidance."""
     result = await describe_table(table="users")
+    data = json.loads(result)
 
-    assert "Column" in result
-    assert "Type" in result
-    assert "|" in result
+    assert data["table"] == "users"
+    assert data["table_schema"] == "testdb"
+    assert data["schema"]["time_index"] == "ts"
+    assert data["schema"]["primary_keys"] == ["id"]
+    assert data["schema"]["columns"][0]["name"] == "id"
+    assert data["semantics"]["available"] is True
+    assert data["semantics"]["found"] is True
+    assert data["semantics"]["signal_type"] == "metric"
+    assert data["semantics"]["options"]["metric.type"] == "counter"
+    assert data["samples"]["included"] is True
+    assert data["samples"]["strategy"] == "latest_by_time_index"
+    assert data["samples"]["limit"] == 5
+    assert len(data["samples"]["rows"]) == 2
+    assert data["guidance"]
+
+
+@pytest.mark.asyncio
+async def test_describe_table_without_samples():
+    """Test describe_table can skip sample rows."""
+    result = await describe_table(table="users", include_samples=False)
+    data = json.loads(result)
+
+    assert data["samples"]["included"] is False
+    assert data["semantics"]["found"] is True
+
+
+@pytest.mark.asyncio
+async def test_describe_table_without_semantics():
+    """Test describe_table can skip table semantic metadata."""
+    result = await describe_table(table="users", include_semantics=False)
+    data = json.loads(result)
+
+    assert data["semantics"]["included"] is False
+    assert data["samples"]["included"] is True
+
+
+@pytest.mark.asyncio
+async def test_describe_table_without_semantic_row():
+    """Test describe_table when table_semantics exists but the table has no row."""
+    result = await describe_table(table="orders")
+    data = json.loads(result)
+
+    assert data["semantics"]["available"] is True
+    assert data["semantics"]["found"] is False
+    assert "No table semantic metadata was found" in data["guidance"][0]
+
+
+@pytest.mark.asyncio
+async def test_describe_table_semantics_unavailable():
+    """Test describe_table gracefully handles old versions without table_semantics."""
+
+    class Cursor:
+        def __init__(self):
+            self.query = ""
+            self._results = []
+
+        def execute(self, query, args=None):
+            self.query = query
+            if "information_schema.table_semantics" in query:
+                raise server.Error("table not found")
+            if "information_schema.columns" in query:
+                self._results = [
+                    ("id", "Int64", "TAG", "NO"),
+                    ("ts", "TimestampMillisecond", "TIMESTAMP", "NO"),
+                ]
+            elif "SELECT * FROM" in query:
+                self._results = [(1, "2024-01-01 00:00:00")]
+
+        def fetchall(self):
+            return self._results
+
+        def fetchone(self):
+            return None
+
+        @property
+        def description(self):
+            if "SELECT * FROM" in self.query:
+                return [("id", None), ("ts", None)]
+            return []
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            pass
+
+    class Connection:
+        def cursor(self):
+            return Cursor()
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            pass
+
+    server._state.pool = None
+    server._state.get_connection = lambda: Connection()
+
+    result = await describe_table(table="users")
+    data = json.loads(result)
+
+    assert data["schema"]["time_index"] == "ts"
+    assert data["semantics"]["available"] is False
+    assert data["semantics"]["found"] is False
+    assert data["samples"]["included"] is True
 
 
 @pytest.mark.asyncio
@@ -472,8 +576,18 @@ async def test_read_table_resource_invalid_name():
 async def test_describe_table_schema_qualified():
     """Test describe_table with schema.table format"""
     result = await describe_table(table="public.users")
-    assert "Column" in result
-    assert "Type" in result
+    data = json.loads(result)
+    assert data["table_schema"] == "public"
+    assert data["table_name"] == "users"
+    assert data["schema"]["time_index"] == "ts"
+
+
+@pytest.mark.asyncio
+async def test_describe_table_sample_limit_clamped():
+    """Test describe_table clamps sample limit."""
+    result = await describe_table(table="users", sample_limit=100)
+    data = json.loads(result)
+    assert data["samples"]["limit"] == 20
 
 
 @pytest.mark.asyncio

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -179,9 +179,13 @@ async def test_describe_table():
 
     assert data["table"] == "users"
     assert data["table_schema"] == "testdb"
+    assert data["table_comment"] == "user activity table"
     assert data["schema"]["time_index"] == "ts"
     assert data["schema"]["primary_keys"] == ["id"]
     assert data["schema"]["columns"][0]["name"] == "id"
+    assert "comment" not in data["schema"]["columns"][0]
+    name_col = next(c for c in data["schema"]["columns"] if c["name"] == "name")
+    assert name_col["comment"] == "user name"
     assert data["semantics"]["available"] is True
     assert data["semantics"]["found"] is True
     assert data["semantics"]["signal_type"] == "metric"
@@ -237,7 +241,9 @@ async def test_describe_table_semantics_unavailable():
             self.query = query
             if "information_schema.table_semantics" in query:
                 raise server.Error("table not found")
-            if "information_schema.columns" in query:
+            if "information_schema.tables" in query:
+                self._results = []
+            elif "information_schema.columns" in query:
                 self._results = [
                     ("id", "Int64", "TAG", "NO"),
                     ("ts", "TimestampMillisecond", "TIMESTAMP", "NO"),
@@ -310,6 +316,8 @@ async def test_describe_table_non_object_semantic_options():
                         "[1, 2, 3]",
                     )
                 ]
+            elif "information_schema.tables" in query:
+                self._results = []
             elif "information_schema.columns" in query:
                 self._results = [
                     ("id", "Int64", "TAG", "NO"),
@@ -730,6 +738,8 @@ async def test_describe_table_catalog_qualified_sample_ignores_catalog():
                     ("ts", "TimestampMillisecond", "TIMESTAMP", "NO"),
                 ]
             elif "information_schema.table_semantics" in query:
+                self._results = []
+            elif "information_schema.tables" in query:
                 self._results = []
             elif "SELECT * FROM" in query:
                 self._results = [(1, "2024-01-01 00:00:00")]

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -712,6 +712,102 @@ async def test_describe_table_catalog_qualified():
 
 
 @pytest.mark.asyncio
+async def test_describe_table_catalog_qualified_sample_ignores_catalog():
+    """The sample query targets schema.table only, never the catalog segment."""
+    executed = []
+
+    class Cursor:
+        def __init__(self):
+            self.query = ""
+            self._results = []
+
+        def execute(self, query, args=None):
+            self.query = query
+            executed.append(query)
+            if "information_schema.columns" in query:
+                self._results = [
+                    ("id", "Int64", "TAG", "NO"),
+                    ("ts", "TimestampMillisecond", "TIMESTAMP", "NO"),
+                ]
+            elif "information_schema.table_semantics" in query:
+                self._results = []
+            elif "SELECT * FROM" in query:
+                self._results = [(1, "2024-01-01 00:00:00")]
+
+        def fetchall(self):
+            return self._results
+
+        def fetchone(self):
+            return None
+
+        @property
+        def description(self):
+            if "SELECT * FROM" in self.query:
+                return [("id", None), ("ts", None)]
+            return []
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            pass
+
+    class Connection:
+        def cursor(self):
+            return Cursor()
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            pass
+
+    server._state.pool = None
+    server._state.get_connection = lambda: Connection()
+
+    result = await describe_table(table="greptime.public.users")
+    data = json.loads(result)
+
+    sample_query = next(q for q in executed if "SELECT * FROM" in q)
+    assert "`public`.`users`" in sample_query
+    assert "greptime" not in sample_query
+    assert data["samples"]["strategy"] == "latest_by_time_index"
+
+
+@pytest.mark.asyncio
+async def test_describe_table_error_returns_json():
+    """On a database Error, describe_table returns a JSON object, not a bare string."""
+
+    class Cursor:
+        def execute(self, query, args=None):
+            raise server.Error("boom")
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            pass
+
+    class Connection:
+        def cursor(self):
+            return Cursor()
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            pass
+
+    server._state.pool = None
+    server._state.get_connection = lambda: Connection()
+
+    result = await describe_table(table="public.users")
+    data = json.loads(result)
+    assert data["table"] == "public.users"
+    assert "Error describing table" in data["error"]
+
+
+@pytest.mark.asyncio
 async def test_describe_table_sample_limit_clamped():
     """Test describe_table clamps sample limit."""
     result = await describe_table(table="users", sample_limit=100)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -286,6 +286,79 @@ async def test_describe_table_semantics_unavailable():
 
 
 @pytest.mark.asyncio
+async def test_describe_table_non_object_semantic_options():
+    """Test describe_table tolerates semantic_options that is valid JSON but not an object."""
+
+    class Cursor:
+        def __init__(self):
+            self.query = ""
+            self._results = []
+
+        def execute(self, query, args=None):
+            self.query = query
+            if "information_schema.table_semantics" in query:
+                self._results = [
+                    (
+                        "greptime",
+                        "testdb",
+                        "users",
+                        1,
+                        "metric",
+                        "opentelemetry",
+                        "",
+                        "declared",
+                        "[1, 2, 3]",
+                    )
+                ]
+            elif "information_schema.columns" in query:
+                self._results = [
+                    ("id", "Int64", "TAG", "NO"),
+                    ("ts", "TimestampMillisecond", "TIMESTAMP", "NO"),
+                ]
+            elif "SELECT * FROM" in query:
+                self._results = [(1, "2024-01-01 00:00:00")]
+
+        def fetchall(self):
+            return self._results
+
+        def fetchone(self):
+            return None
+
+        @property
+        def description(self):
+            if "SELECT * FROM" in self.query:
+                return [("id", None), ("ts", None)]
+            return []
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            pass
+
+    class Connection:
+        def cursor(self):
+            return Cursor()
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            pass
+
+    server._state.pool = None
+    server._state.get_connection = lambda: Connection()
+
+    result = await describe_table(table="users")
+    data = json.loads(result)
+
+    assert data["semantics"]["found"] is True
+    assert data["semantics"]["options"] == {}
+    assert data["semantics"]["raw_options"] == "[1, 2, 3]"
+    assert "not a JSON object" in data["semantics"]["options_parse_error"]
+
+
+@pytest.mark.asyncio
 async def test_describe_table_not_found():
     """Test describe_table surfaces a clear error when no columns are visible."""
 
@@ -622,6 +695,16 @@ async def test_read_table_resource_invalid_name():
 async def test_describe_table_schema_qualified():
     """Test describe_table with schema.table format"""
     result = await describe_table(table="public.users")
+    data = json.loads(result)
+    assert data["table_schema"] == "public"
+    assert data["table_name"] == "users"
+    assert data["schema"]["time_index"] == "ts"
+
+
+@pytest.mark.asyncio
+async def test_describe_table_catalog_qualified():
+    """Test describe_table parses catalog.schema.table, ignoring the catalog."""
+    result = await describe_table(table="greptime.public.users")
     data = json.loads(result)
     assert data["table_schema"] == "public"
     assert data["table_name"] == "users"

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -286,6 +286,52 @@ async def test_describe_table_semantics_unavailable():
 
 
 @pytest.mark.asyncio
+async def test_describe_table_not_found():
+    """Test describe_table surfaces a clear error when no columns are visible."""
+
+    class Cursor:
+        def __init__(self):
+            self.query = ""
+
+        def execute(self, query, args=None):
+            self.query = query
+
+        def fetchall(self):
+            return []
+
+        @property
+        def description(self):
+            return []
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            pass
+
+    class Connection:
+        def cursor(self):
+            return Cursor()
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            pass
+
+    server._state.pool = None
+    server._state.get_connection = lambda: Connection()
+
+    result = await describe_table(table="ghost")
+    data = json.loads(result)
+
+    assert data["schema"]["columns"] == []
+    assert "not found" in data["error"]
+    assert "semantics" not in data
+    assert "samples" not in data
+
+
+@pytest.mark.asyncio
 async def test_describe_table_invalid_name():
     """Test describe_table with invalid table name"""
     with pytest.raises(ValueError) as excinfo:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -222,6 +222,21 @@ def test_format_results_json():
     assert data[0]["b"] == 2
 
 
+def test_format_results_json_non_native_values():
+    """Test JSON format handles non-JSON-native values without crashing."""
+    from decimal import Decimal
+
+    result = format_results(
+        ["amount", "payload"],
+        [(Decimal("3.14"), b"\x00\x01")],
+        "json",
+        mask_enabled=False,
+    )
+    data = json.loads(result)
+    assert data[0]["amount"] == "3.14"
+    assert data[0]["payload"] == "b'\\x00\\x01'"
+
+
 def test_format_results_markdown():
     """Test format_results with markdown format"""
     result = format_results(["a", "b"], [(1, 2)], "markdown")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -463,6 +463,12 @@ def test_validate_table_name_schema_qualified():
     assert validate_table_name("my_schema.my_table") == "my_schema.my_table"
 
 
+def test_validate_table_name_catalog_qualified():
+    """Test validate_table_name accepts GreptimeDB-style catalog.schema.table"""
+    assert validate_table_name("greptime.public.users") == "greptime.public.users"
+    assert validate_table_name("cat.schema_name.tbl") == "cat.schema_name.tbl"
+
+
 def test_validate_table_name_invalid():
     """Test validate_table_name rejects invalid names"""
     with pytest.raises(ValueError) as excinfo:
@@ -474,7 +480,7 @@ def test_validate_table_name_invalid():
     assert "Invalid table name" in str(excinfo.value)
 
     with pytest.raises(ValueError) as excinfo:
-        validate_table_name("schema.table.extra")
+        validate_table_name("catalog.schema.table.extra")
     assert "Invalid table name" in str(excinfo.value)
 
     with pytest.raises(ValueError) as excinfo:


### PR DESCRIPTION
Improve `describe_table` to include 
* semantic metadata when available, 
* the latest sample data, 
* query guidance
* table comment and column comments.

Sample output:

```json

 {
    "table": "mcp_comment_demo",
    "table_schema": "public",
    "table_name": "mcp_comment_demo",
    "schema": {
      "columns": [
        {
          "name": "host",
          "data_type": "string",
          "semantic_type": "TAG",
          "nullable": true,
          "comment": "source host name"
        },
        {
          "name": "cpu",
          "data_type": "double",
          "semantic_type": "FIELD",
          "nullable": true,
          "comment": "cpu usage percent"
        },
        {
          "name": "ts",
          "data_type": "timestamp(3)",
          "semantic_type": "TIMESTAMP",
          "nullable": false
        }
      ],
      "time_index": "ts",
      "primary_keys": [
        "host"
      ]
    },
    "semantics": {
      "included": true,
      "available": true,
      "found": false
    },
    "samples": {
      "included": true,
      "strategy": "latest_by_time_index",
      "limit": 2,
      "columns": [
        "host",
        "cpu",
        "ts"
      ],
      "rows": [
        {
          "host": "h2",
          "cpu": 33.0,
          "ts": "2026-06-08 10:39:35.494000"
        },
        {
          "host": "h1",
          "cpu": 12.5,
          "ts": "2026-06-08 10:39:35.494000"
        }
      ]
    },
    "guidance": [
      "No table semantic metadata was found. Treat signal type and query pattern as schema/sample-based inference.",
      "Sample rows are ordered by time index ts descending."
    ],
    "table_comment": "demo metrics table for MCP"
  }

```