### PR TITLE
feat: add verbose mode to explain_query for scan-level metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ For Claude Desktop, add this to your config (`~/Library/Application Support/Clau
 | `execute_tql` | Execute TQL (PromQL-compatible) queries for time-series analysis |
 | `query_range` | Execute time-window aggregation queries with RANGE/ALIGN syntax |
 | `describe_table` | Inspect a table profile: schema, semantic metadata, latest sample rows, and query guidance |
-| `explain_query` | Analyze SQL or TQL query execution plans |
+| `explain_query` | Analyze SQL or TQL query execution plans (`analyze=true` for runtime stats, `verbose=true` for per-partition scan metrics) |
 | `health_check` | Check database connection status and server version |
 
 ### Pipeline Management

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ For Claude Desktop, add this to your config (`~/Library/Application Support/Clau
 | `execute_tql` | Execute TQL (PromQL-compatible) queries for time-series analysis |
 | `query_range` | Execute time-window aggregation queries with RANGE/ALIGN syntax |
 | `describe_table` | Inspect a table profile: schema, semantic metadata, latest sample rows, and query guidance |
-| `explain_query` | Analyze SQL or TQL query execution plans (`analyze=true` for runtime stats, `verbose=true` for per-partition scan metrics) |
+| `explain_query` | Analyze SQL or TQL query execution plans (`analyze=true` for runtime stats; add `verbose=true` alongside `analyze=true` for per-partition scan metrics and index-pruning counters) |
 | `health_check` | Check database connection status and server version |
 
 ### Pipeline Management

--- a/docs/llm-instructions.md
+++ b/docs/llm-instructions.md
@@ -13,7 +13,7 @@ You have access to a GreptimeDB MCP server for querying and managing time-series
 - `query_range`: Time-window aggregation with RANGE/ALIGN syntax
 - `describe_table`: Inspect a table profile: schema, semantic metadata, latest sample rows, and query guidance
 - `health_check`: Check database connection status
-- `explain_query`: Analyze query execution plans (`analyze=true` for runtime stats, `verbose=true` for per-partition scan metrics)
+- `explain_query`: Analyze query execution plans (`analyze=true` for runtime stats; add `verbose=true` alongside `analyze=true` for per-partition scan metrics and index-pruning counters)
 
 ### Pipeline Management
 - `list_pipelines`: View existing log pipelines

--- a/docs/llm-instructions.md
+++ b/docs/llm-instructions.md
@@ -13,7 +13,7 @@ You have access to a GreptimeDB MCP server for querying and managing time-series
 - `query_range`: Time-window aggregation with RANGE/ALIGN syntax
 - `describe_table`: Inspect a table profile: schema, semantic metadata, latest sample rows, and query guidance
 - `health_check`: Check database connection status
-- `explain_query`: Analyze query execution plans
+- `explain_query`: Analyze query execution plans (`analyze=true` for runtime stats, `verbose=true` for per-partition scan metrics)
 
 ### Pipeline Management
 - `list_pipelines`: View existing log pipelines

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "greptimedb-mcp-server"
-version = "0.5.0"
+version = "0.5.1"
 description = "MCP server for GreptimeDB with SQL/TQL/PromQL support, sensitive data masking, and prompt templates for observability data analysis."
 readme = "README.md"
 license = {text = "MIT"}

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/GreptimeTeam/greptimedb-mcp-server",
     "source": "github"
   },
-  "version": "0.5.0",
+  "version": "0.5.1",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "greptimedb-mcp-server",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "transport": {
         "type": "stdio"
       },

--- a/src/greptimedb_mcp_server/server.py
+++ b/src/greptimedb_mcp_server/server.py
@@ -895,6 +895,13 @@ async def query_range(
 async def explain_query(
     query: Annotated[str, "SQL or TQL query to analyze"],
     analyze: Annotated[bool, "Execute and show actual metrics"] = False,
+    verbose: Annotated[
+        bool,
+        "Show detailed per-partition scan metrics; combine with "
+        "analyze=true to reveal index-pruning counters "
+        "(rg_bloom_filtered, rg_inverted_filtered, rg_minmax_filtered, "
+        "rows_bloom_filtered, rows_inverted_filtered)",
+    ] = False,
 ) -> str:
     """Analyze SQL or TQL query execution plan."""
     state = get_state()
@@ -907,8 +914,9 @@ async def explain_query(
         return f"Error: Dangerous operation blocked: {reason}"
 
     if query.strip().upper().startswith("TQL"):
-        # Replace TQL EVAL or TQL EVALUATE at start with TQL ANALYZE/EXPLAIN
-        replacement = "TQL ANALYZE" if analyze else "TQL EXPLAIN"
+        # Replace leading TQL EVAL/EVALUATE with TQL ANALYZE/EXPLAIN [VERBOSE].
+        base = "TQL ANALYZE" if analyze else "TQL EXPLAIN"
+        replacement = f"{base} VERBOSE" if verbose else base
         explain_query_str = re.sub(
             r"^\s*TQL\s+(EVAL(UATE)?)",
             replacement,
@@ -917,10 +925,13 @@ async def explain_query(
             flags=re.IGNORECASE,
         )
     else:
+        # EXPLAIN [ANALYZE] [VERBOSE] <query>; modifiers are orthogonal.
+        keywords = "EXPLAIN"
         if analyze:
-            explain_query_str = f"EXPLAIN ANALYZE {query}"
-        else:
-            explain_query_str = f"EXPLAIN {query}"
+            keywords += " ANALYZE"
+        if verbose:
+            keywords += " VERBOSE"
+        explain_query_str = f"{keywords} {query}"
 
     def _sync_explain():
         with state.get_connection() as conn:

--- a/src/greptimedb_mcp_server/templates/query_performance_tuning/template.md
+++ b/src/greptimedb_mcp_server/templates/query_performance_tuning/template.md
@@ -20,8 +20,8 @@ Query:
 1. Run `explain_query(query=..., analyze=false)` first.
 2. If the query is safe and bounded by time or `LIMIT`, run
    `explain_query(query=..., analyze=true)`.
-   If scan-level metrics are needed, use `execute_sql` with
-   `EXPLAIN ANALYZE VERBOSE <query>`.
+   For scan-level metrics (per-partition index pruning, row-group
+   filtering), run `explain_query(query=..., analyze=true, verbose=true)`.
 3. Use `describe_table` or `SHOW CREATE TABLE` only to confirm the time index, primary key, and indexed columns needed to interpret the plan.
 4. Check whether time filters, primary key ordering, partition pruning, and
    secondary indexes can be used.

--- a/src/greptimedb_mcp_server/templates/table_operation/template.md
+++ b/src/greptimedb_mcp_server/templates/table_operation/template.md
@@ -13,7 +13,7 @@ qualified name directly.
 ## Available Tools
 
 - `describe_table` - Inspect table profile: schema, semantic metadata, sample rows
-- `explain_query` - Analyze query execution plan (set `analyze=true` for runtime stats)
+- `explain_query` - Analyze query execution plan (set `analyze=true` for runtime stats, add `verbose=true` for per-partition scan metrics)
 - `execute_sql` - Run diagnostic SQL queries
 
 ## Schema Analysis

--- a/src/greptimedb_mcp_server/templates/table_operation/template.md
+++ b/src/greptimedb_mcp_server/templates/table_operation/template.md
@@ -13,7 +13,7 @@ qualified name directly.
 ## Available Tools
 
 - `describe_table` - Inspect table profile: schema, semantic metadata, sample rows
-- `explain_query` - Analyze query execution plan (set `analyze=true` for runtime stats, add `verbose=true` for per-partition scan metrics)
+- `explain_query` - Analyze query execution plan (set `analyze=true` for runtime stats; add `verbose=true` together with `analyze=true` for per-partition scan metrics and index-pruning counters)
 - `execute_sql` - Run diagnostic SQL queries
 
 ## Schema Analysis

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -696,6 +696,51 @@ async def test_explain_query_dangerous_blocked():
     assert "Error: Dangerous operation blocked" in result
 
 
+def _spy_executed_queries(monkeypatch):
+    """Capture every SQL string passed to the mocked cursor."""
+    import conftest
+
+    captured = []
+    original = conftest.MockCursor.execute
+
+    def spy(self, query, args=None):
+        captured.append(query)
+        return original(self, query, args)
+
+    monkeypatch.setattr(conftest.MockCursor, "execute", spy)
+    return captured
+
+
+@pytest.mark.asyncio
+async def test_explain_query_with_verbose(monkeypatch):
+    """analyze=true + verbose=true must emit EXPLAIN ANALYZE VERBOSE"""
+    captured = _spy_executed_queries(monkeypatch)
+
+    await explain_query(query="SELECT * FROM users", analyze=True, verbose=True)
+
+    assert any("EXPLAIN ANALYZE VERBOSE" in q for q in captured)
+
+
+@pytest.mark.asyncio
+async def test_explain_query_verbose_without_analyze(monkeypatch):
+    """verbose is orthogonal to analyze: EXPLAIN VERBOSE without ANALYZE"""
+    captured = _spy_executed_queries(monkeypatch)
+
+    await explain_query(query="SELECT * FROM users", verbose=True)
+
+    assert any(q.strip().startswith("EXPLAIN VERBOSE") for q in captured)
+
+
+@pytest.mark.asyncio
+async def test_explain_query_tql_verbose(monkeypatch):
+    """verbose=true on TQL must emit TQL ANALYZE VERBOSE"""
+    captured = _spy_executed_queries(monkeypatch)
+
+    await explain_query(query="TQL EVAL (0, 100, '30s') up", analyze=True, verbose=True)
+
+    assert any("TQL ANALYZE VERBOSE" in q for q in captured)
+
+
 @pytest.mark.asyncio
 async def test_read_table_resource():
     """Test reading a table resource"""


### PR DESCRIPTION
## Problem

`explain_query` only ever issued `EXPLAIN` or `EXPLAIN ANALYZE`, never `EXPLAIN ANALYZE VERBOSE`. The index-pruning counters that matter for diagnosing query performance — `rg_bloom_filtered`, `rg_inverted_filtered`, `rg_minmax_filtered`, `rows_bloom_filtered`, `rows_inverted_filtered` — live in mito2's per-partition `ScanMetricsSet` and only render under `VERBOSE` (and only when `> 0`). Non-verbose output just shows the coarse `partition_count` (files / file_ranges), which says nothing about row-group-level pruning.

The `query_performance_tuning` prompt even acknowledged the gap: it told users to fall back to `execute_sql` with `EXPLAIN ANALYZE VERBOSE <query>` because the tool couldn't produce it.

## Change

- Add a `verbose: bool = False` parameter to `explain_query`, orthogonal to `analyze`.
  - SQL path: `EXPLAIN [ANALYZE] [VERBOSE] <query>`
  - TQL path: `TQL ANALYZE|EXPLAIN [VERBOSE] ...` (TQL supports VERBOSE too, verified against a live instance)
- Update the `query_performance_tuning` prompt to use `explain_query(analyze=true, verbose=true)` instead of the `execute_sql` workaround.
- Sync tool descriptions in README, `docs/llm-instructions.md`, and the `table_operation` prompt.

Scan-level index-pruning counters require `analyze=true, verbose=true` (the counters are only produced during actual execution).

## Tests

Added 3 tests that spy on the executed SQL and assert correct keyword assembly:
- `EXPLAIN ANALYZE VERBOSE` (analyze + verbose)
- `EXPLAIN VERBOSE` (verbose without analyze — confirms orthogonality)
- `TQL ANALYZE VERBOSE` (TQL path)

Full suite: 188 passed, flake8 clean, black clean.