### PR TITLE
fix: pin mcp<2, add clean-install smoke and black-box integration CI

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -39,10 +39,8 @@ jobs:
       run: |
         uv run pytest
 
-  # Installs the built wheel the way an end user would: fresh dependency
-  # resolution from the published metadata, no dev dependencies, no source tree
-  # on sys.path. Covers what `uv sync` + pytest cannot -- wheel packaging (the
-  # templates/ data files) and the console script entry point.
+  # Installs the wheel the way an end user would: fresh dependency resolution
+  # from the published metadata, no dev dependencies, no source tree on sys.path.
   install-smoke:
     runs-on: ubuntu-latest
     steps:
@@ -60,10 +58,8 @@ jobs:
         /tmp/smoke/bin/python -c "from mcp.server.fastmcp import FastMCP; import greptimedb_mcp_server.server"
         /tmp/smoke/bin/greptimedb-mcp-server --help
 
-  # Black-box tests: a real MCP client drives a real server subprocess against a
-  # real GreptimeDB. Started with `docker run` rather than `services:` because
-  # the image needs a `standalone start ...` command, which `services:` cannot
-  # provide.
+  # Uses `docker run` rather than `services:` because the image needs a
+  # `standalone start ...` command, which `services:` cannot provide.
   integration:
     runs-on: ubuntu-latest
     steps:
@@ -79,8 +75,8 @@ jobs:
           standalone start --http-addr 0.0.0.0:4000 --mysql-addr 0.0.0.0:4002
     - name: Wait for GreptimeDB
       run: |
-        # /status returns the build info, so this also proves we reached
-        # GreptimeDB itself and not some other service on the port.
+        # Grepping /status for the build info also proves we reached GreptimeDB
+        # and not some other service bound to the port.
         for _ in $(seq 1 60); do
           if curl -sf http://127.0.0.1:4000/status | grep -q '"version"'; then
             curl -s http://127.0.0.1:4000/status

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -38,3 +38,63 @@ jobs:
     - name: Test with pytest
       run: |
         uv run pytest
+
+  # Installs the built wheel the way an end user would: fresh dependency
+  # resolution from the published metadata, no dev dependencies, no source tree
+  # on sys.path. Covers what `uv sync` + pytest cannot -- wheel packaging (the
+  # templates/ data files) and the console script entry point.
+  install-smoke:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Install the latest version of uv
+      uses: astral-sh/setup-uv@v5
+    - name: Build wheel
+      run: uv build --wheel
+    - name: Install wheel in a clean environment
+      run: |
+        uv venv --python 3.11 /tmp/smoke
+        VIRTUAL_ENV=/tmp/smoke uv pip install dist/*.whl
+    - name: Import smoke test
+      run: |
+        /tmp/smoke/bin/python -c "from mcp.server.fastmcp import FastMCP; import greptimedb_mcp_server.server"
+        /tmp/smoke/bin/greptimedb-mcp-server --help
+
+  # Black-box tests: a real MCP client drives a real server subprocess against a
+  # real GreptimeDB. Started with `docker run` rather than `services:` because
+  # the image needs a `standalone start ...` command, which `services:` cannot
+  # provide.
+  integration:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Install the latest version of uv
+      uses: astral-sh/setup-uv@v5
+    - run: uv python pin cp311
+    - name: Start GreptimeDB
+      run: |
+        docker run -d --name greptimedb \
+          -p 127.0.0.1:4000:4000 -p 127.0.0.1:4002:4002 \
+          greptime/greptimedb:v1.2.0-beta.1 \
+          standalone start --http-addr 0.0.0.0:4000 --mysql-addr 0.0.0.0:4002
+    - name: Wait for GreptimeDB
+      run: |
+        # /status returns the build info, so this also proves we reached
+        # GreptimeDB itself and not some other service on the port.
+        for _ in $(seq 1 60); do
+          if curl -sf http://127.0.0.1:4000/status | grep -q '"version"'; then
+            curl -s http://127.0.0.1:4000/status
+            exit 0
+          fi
+          sleep 2
+        done
+        echo "GreptimeDB did not become ready in time"
+        docker logs greptimedb
+        exit 1
+    - name: Install dependencies
+      run: uv sync
+    - name: Run integration tests
+      run: uv run pytest -m integration tests/integration -v
+    - name: GreptimeDB logs
+      if: failure()
+      run: docker logs greptimedb

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ greptimedb-mcp-server \
 
 ### HTTP Server Mode
 
-For containerized or Kubernetes deployments. Requires `mcp>=1.8.0`:
+For containerized or Kubernetes deployments. Requires `mcp>=1.8.0,<2`:
 
 ```bash
 # Streamable HTTP (recommended for production)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,13 +4,13 @@ build-backend = "hatchling.build"
 
 [project]
 name = "greptimedb-mcp-server"
-version = "0.5.1"
+version = "0.5.2"
 description = "MCP server for GreptimeDB with SQL/TQL/PromQL support, sensitive data masking, and prompt templates for observability data analysis."
 readme = "README.md"
 license = {text = "MIT"}
 requires-python = ">=3.11"
 dependencies = [
-    "mcp>=1.8.0",
+    "mcp>=1.8.0,<2",
     "mysql-connector-python>=9.7.0",
     "pyyaml>=6.0.2",
     "aiohttp>=3.9.0",

--- a/pytest.ini
+++ b/pytest.ini
@@ -3,3 +3,6 @@ asyncio_mode = auto
 asyncio_default_fixture_loop_scope = function
 testpaths = tests
 python_files = test_*.py
+markers =
+    integration: black-box test requiring a live GreptimeDB instance
+addopts = -m "not integration"

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/GreptimeTeam/greptimedb-mcp-server",
     "source": "github"
   },
-  "version": "0.5.1",
+  "version": "0.5.2",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "greptimedb-mcp-server",
-      "version": "0.5.1",
+      "version": "0.5.2",
       "transport": {
         "type": "stdio"
       },

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,204 @@
+"""Fixtures for black-box tests against a live GreptimeDB instance.
+
+Nothing is mocked here: the MCP server runs as a real subprocess and talks to a
+real database over the MySQL and HTTP protocols. Seed data is loaded through a
+direct MySQL connection rather than through the server, so a broken server
+cannot make its own fixtures pass.
+
+Deselected by default; run with `pytest -m integration`.
+"""
+
+import os
+import socket
+import subprocess
+import sys
+import time
+from contextlib import asynccontextmanager
+from dataclasses import dataclass
+
+import mysql.connector
+import pytest
+from mcp import ClientSession, StdioServerParameters
+from mcp.client.stdio import stdio_client
+from mcp.client.streamable_http import streamablehttp_client
+
+HOST = os.getenv("GREPTIMEDB_IT_HOST", "127.0.0.1")
+MYSQL_PORT = int(os.getenv("GREPTIMEDB_IT_PORT", "4002"))
+HTTP_PORT = int(os.getenv("GREPTIMEDB_IT_HTTP_PORT", "4000"))
+DATABASE = "public"
+
+METRICS_TABLE = "it_cpu_metrics"
+CREDENTIALS_TABLE = "it_credentials"
+
+METRIC_HOSTS = ("host-a", "host-b")
+METRIC_POINTS = 12
+METRIC_INTERVAL_MS = 10_000
+
+SECRET_PASSWORD = "hunter2"
+SECRET_API_KEY = "sk-live-secret"
+MASK_PLACEHOLDER = "******"
+
+
+@dataclass(frozen=True)
+class SeedData:
+    """Describes the rows loaded by the `seed` fixture."""
+
+    base_ms: int
+    hosts: tuple[str, ...]
+    points_per_host: int
+
+    @property
+    def row_count(self) -> int:
+        return len(self.hosts) * self.points_per_host
+
+    @property
+    def earliest_ms(self) -> int:
+        return self.base_ms - (self.points_per_host - 1) * METRIC_INTERVAL_MS
+
+
+def _connect():
+    return mysql.connector.connect(
+        host=HOST,
+        port=MYSQL_PORT,
+        user="",
+        password="",
+        database=DATABASE,
+    )
+
+
+@pytest.fixture(scope="session")
+def db():
+    conn = _connect()
+    yield conn
+    conn.close()
+
+
+@pytest.fixture(scope="session")
+def seed(db):
+    cursor = db.cursor()
+    for table in (METRICS_TABLE, CREDENTIALS_TABLE):
+        cursor.execute(f"DROP TABLE IF EXISTS {table}")
+
+    cursor.execute(f"""CREATE TABLE {METRICS_TABLE} (
+            ts TIMESTAMP TIME INDEX,
+            host STRING PRIMARY KEY,
+            cpu DOUBLE
+        )""")
+    # `password` is a reserved word in GreptimeDB's parser, hence user_password.
+    # Both column names still match the default masking patterns.
+    cursor.execute(f"""CREATE TABLE {CREDENTIALS_TABLE} (
+            ts TIMESTAMP TIME INDEX,
+            username STRING PRIMARY KEY,
+            user_password STRING,
+            api_key STRING
+        )""")
+
+    base_ms = int(time.time() * 1000)
+    metric_rows = [
+        (base_ms - i * METRIC_INTERVAL_MS, host, 50.0 + i)
+        for host in METRIC_HOSTS
+        for i in range(METRIC_POINTS)
+    ]
+    cursor.executemany(
+        f"INSERT INTO {METRICS_TABLE} (ts, host, cpu) VALUES (%s, %s, %s)",
+        metric_rows,
+    )
+    cursor.execute(
+        f"INSERT INTO {CREDENTIALS_TABLE} (ts, username, user_password, api_key) "
+        f"VALUES (%s, %s, %s, %s)",
+        (base_ms, "alice", SECRET_PASSWORD, SECRET_API_KEY),
+    )
+    db.commit()
+
+    yield SeedData(
+        base_ms=base_ms,
+        hosts=METRIC_HOSTS,
+        points_per_host=METRIC_POINTS,
+    )
+
+    for table in (METRICS_TABLE, CREDENTIALS_TABLE):
+        cursor.execute(f"DROP TABLE IF EXISTS {table}")
+    db.commit()
+
+
+def server_argv(**overrides) -> list[str]:
+    """Build the CLI argv for a server subprocess pointed at the test instance."""
+    flags = {
+        "--host": HOST,
+        "--port": str(MYSQL_PORT),
+        "--http-port": str(HTTP_PORT),
+        "--database": DATABASE,
+        "--audit-enabled": "false",
+    }
+    flags.update(overrides)
+    argv = []
+    for flag, value in flags.items():
+        argv += [flag, value]
+    return argv
+
+
+@asynccontextmanager
+async def stdio_session(**overrides):
+    """Run the server over stdio and yield an initialized MCP client session."""
+    params = StdioServerParameters(
+        command=sys.executable,
+        args=["-m", "greptimedb_mcp_server.server", *server_argv(**overrides)],
+    )
+    async with stdio_client(params) as (read, write):
+        async with ClientSession(read, write) as session:
+            await session.initialize()
+            yield session
+
+
+def _free_port() -> int:
+    with socket.socket() as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+def _wait_for_port(port: int, timeout: float = 30.0) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        with socket.socket() as sock:
+            sock.settimeout(0.5)
+            if sock.connect_ex(("127.0.0.1", port)) == 0:
+                return
+        time.sleep(0.2)
+    raise TimeoutError(f"MCP server did not start listening on port {port}")
+
+
+@asynccontextmanager
+async def streamable_http_session(**overrides):
+    """Run the server over streamable-http and yield an initialized session."""
+    port = _free_port()
+    argv = server_argv(
+        **{
+            "--transport": "streamable-http",
+            "--listen-host": "127.0.0.1",
+            "--listen-port": str(port),
+            **overrides,
+        }
+    )
+    process = subprocess.Popen(
+        [sys.executable, "-m", "greptimedb_mcp_server.server", *argv]
+    )
+    try:
+        _wait_for_port(port)
+        async with streamablehttp_client(f"http://127.0.0.1:{port}/mcp") as (
+            read,
+            write,
+            _,
+        ):
+            async with ClientSession(read, write) as session:
+                await session.initialize()
+                yield session
+    finally:
+        process.terminate()
+        process.wait(timeout=15)
+
+
+async def call_text(session: ClientSession, name: str, arguments=None) -> str:
+    """Call a tool and return its text content."""
+    result = await session.call_tool(name, arguments or {})
+    assert result.content, f"tool {name} returned no content"
+    return "\n".join(block.text for block in result.content if block.type == "text")

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,9 +1,7 @@
 """Fixtures for black-box tests against a live GreptimeDB instance.
 
-Nothing is mocked here: the MCP server runs as a real subprocess and talks to a
-real database over the MySQL and HTTP protocols. Seed data is loaded through a
-direct MySQL connection rather than through the server, so a broken server
-cannot make its own fixtures pass.
+Seed data is loaded over a direct MySQL connection rather than through the
+server, so a broken server cannot make its own fixtures pass.
 
 Deselected by default; run with `pytest -m integration`.
 """
@@ -41,8 +39,6 @@ MASK_PLACEHOLDER = "******"
 
 @dataclass(frozen=True)
 class SeedData:
-    """Describes the rows loaded by the `seed` fixture."""
-
     base_ms: int
     hosts: tuple[str, ...]
     points_per_host: int
@@ -122,13 +118,16 @@ def seed(db):
 
 
 def server_argv(**overrides) -> list[str]:
-    """Build the CLI argv for a server subprocess pointed at the test instance."""
+    """Build the CLI argv for a server subprocess pointed at the test instance.
+
+    Audit logging is left enabled on purpose: it monkey-patches the SDK's private
+    tool manager, so every tool call here also proves that hook still works.
+    """
     flags = {
         "--host": HOST,
         "--port": str(MYSQL_PORT),
         "--http-port": str(HTTP_PORT),
         "--database": DATABASE,
-        "--audit-enabled": "false",
     }
     flags.update(overrides)
     argv = []
@@ -194,7 +193,11 @@ async def streamable_http_session(**overrides):
                 yield session
     finally:
         process.terminate()
-        process.wait(timeout=15)
+        try:
+            process.wait(timeout=15)
+        except subprocess.TimeoutExpired:
+            process.kill()
+            process.wait()
 
 
 async def call_text(session: ClientSession, name: str, arguments=None) -> str:

--- a/tests/integration/test_e2e.py
+++ b/tests/integration/test_e2e.py
@@ -1,0 +1,318 @@
+"""Black-box tests: real MCP client -> real server subprocess -> real GreptimeDB.
+
+Each test opens its own stdio session. The session is entered inside the test
+body rather than in a fixture because unwinding anyio cancel scopes during
+pytest-asyncio fixture finalization happens on a different task and fails.
+"""
+
+import json
+
+import pytest
+from pydantic import AnyUrl
+
+from .conftest import (
+    CREDENTIALS_TABLE,
+    MASK_PLACEHOLDER,
+    METRICS_TABLE,
+    SECRET_API_KEY,
+    SECRET_PASSWORD,
+    call_text,
+    stdio_session,
+)
+
+pytestmark = pytest.mark.integration
+
+
+async def test_tool_catalog(seed):
+    async with stdio_session() as client:
+        tools = {tool.name for tool in (await client.list_tools()).tools}
+    assert {
+        "execute_sql",
+        "describe_table",
+        "health_check",
+        "execute_tql",
+        "query_range",
+        "explain_query",
+        "list_pipelines",
+        "create_pipeline",
+        "dryrun_pipeline",
+        "delete_pipeline",
+        "list_dashboards",
+        "create_dashboard",
+        "delete_dashboard",
+    } <= tools
+
+
+async def test_health_check(seed):
+    async with stdio_session() as client:
+        result = json.loads(await call_text(client, "health_check"))
+    assert result["status"] == "healthy"
+    assert "GreptimeDB" in result["version"]
+
+
+async def test_execute_sql_json(seed):
+    async with stdio_session() as client:
+        payload = json.loads(
+            await call_text(
+                client,
+                "execute_sql",
+                {
+                    "query": f"SELECT count(*) AS n FROM {METRICS_TABLE}",
+                    "format": "json",
+                },
+            )
+        )
+    assert payload["data"][0]["n"] == seed.row_count
+
+
+async def test_execute_sql_csv_and_markdown(seed):
+    query = f"SELECT host, cpu FROM {METRICS_TABLE} LIMIT 1"
+    async with stdio_session() as client:
+        csv_out = await call_text(
+            client, "execute_sql", {"query": query, "format": "csv"}
+        )
+        md_out = await call_text(
+            client, "execute_sql", {"query": query, "format": "markdown"}
+        )
+
+    assert csv_out.splitlines()[0] == "host,cpu"
+    assert md_out.lstrip().startswith("|")
+    assert "host" in md_out
+
+
+async def test_execute_sql_limit_truncates(seed):
+    async with stdio_session() as client:
+        payload = json.loads(
+            await call_text(
+                client,
+                "execute_sql",
+                {
+                    "query": f"SELECT * FROM {METRICS_TABLE}",
+                    "format": "json",
+                    "limit": 5,
+                },
+            )
+        )
+    assert payload["row_count"] == 5
+    assert payload["truncated"] is True
+
+
+async def test_read_only_server_blocks_ddl(seed, db):
+    async with stdio_session() as client:
+        output = await call_text(
+            client, "execute_sql", {"query": f"DROP TABLE {METRICS_TABLE}"}
+        )
+    assert "Dangerous operation blocked" in output
+
+    cursor = db.cursor()
+    cursor.execute(f"SHOW TABLES LIKE '{METRICS_TABLE}'")
+    assert cursor.fetchall(), "security gate let the DROP through"
+
+
+async def test_allow_write_permits_ddl(seed, db):
+    table = "it_write_mode_probe"
+    async with stdio_session(**{"--allow-write": "true"}) as client:
+        await call_text(
+            client,
+            "execute_sql",
+            {"query": f"CREATE TABLE {table} (ts TIMESTAMP TIME INDEX, v DOUBLE)"},
+        )
+
+    cursor = db.cursor()
+    try:
+        cursor.execute(f"SHOW TABLES LIKE '{table}'")
+        assert cursor.fetchall(), "write mode did not create the table"
+    finally:
+        cursor.execute(f"DROP TABLE IF EXISTS {table}")
+        db.commit()
+
+
+async def test_describe_table(seed):
+    async with stdio_session() as client:
+        profile = json.loads(
+            await call_text(client, "describe_table", {"table": METRICS_TABLE})
+        )
+    assert profile["table_name"] == METRICS_TABLE
+    assert profile["schema"]["time_index"] == "ts"
+    columns = {column["name"] for column in profile["schema"]["columns"]}
+    assert {"ts", "host", "cpu"} <= columns
+    assert profile["samples"]["included"] is True
+    assert profile["samples"]["rows"]
+
+
+async def test_describe_missing_table(seed):
+    async with stdio_session() as client:
+        profile = json.loads(
+            await call_text(client, "describe_table", {"table": "it_does_not_exist"})
+        )
+    assert "not found" in profile["error"]
+
+
+async def test_query_range(seed):
+    async with stdio_session() as client:
+        payload = json.loads(
+            await call_text(
+                client,
+                "query_range",
+                {
+                    "table": METRICS_TABLE,
+                    "select": "ts, host, avg(cpu) RANGE '30s'",
+                    "align": "30s",
+                    "by": "host",
+                    "order_by": "ts DESC",
+                    "format": "json",
+                },
+            )
+        )
+    assert payload["row_count"] > 0
+    assert "ALIGN '30s'" in payload["query"]
+
+
+async def test_execute_tql(seed):
+    start = seed.earliest_ms // 1000 - 60
+    end = seed.base_ms // 1000 + 60
+    async with stdio_session() as client:
+        payload = json.loads(
+            await call_text(
+                client,
+                "execute_tql",
+                {
+                    "query": METRICS_TABLE,
+                    "start": str(start),
+                    "end": str(end),
+                    "step": "30s",
+                    "format": "json",
+                },
+            )
+        )
+    assert payload["row_count"] > 0
+    assert payload["tql"].startswith("TQL EVAL")
+
+
+async def test_explain_query(seed):
+    async with stdio_session() as client:
+        plan = await call_text(
+            client, "explain_query", {"query": f"SELECT * FROM {METRICS_TABLE}"}
+        )
+    assert "TableScan" in plan
+    assert METRICS_TABLE in plan
+
+
+async def test_explain_analyze_verbose_reports_metrics(seed):
+    async with stdio_session() as client:
+        plan = await call_text(
+            client,
+            "explain_query",
+            {
+                "query": f"SELECT * FROM {METRICS_TABLE}",
+                "analyze": True,
+                "verbose": True,
+            },
+        )
+    assert "output_rows" in plan
+
+
+async def test_read_table_resource(seed):
+    async with stdio_session() as client:
+        result = await client.read_resource(AnyUrl(f"greptime://{METRICS_TABLE}/data"))
+    body = result.contents[0].text
+    assert body.splitlines()[0] == "ts,host,cpu"
+    assert len(body.splitlines()) == seed.row_count + 1
+
+
+async def test_masking_hides_sensitive_columns(seed):
+    query = f"SELECT * FROM {CREDENTIALS_TABLE}"
+    async with stdio_session() as client:
+        output = await call_text(
+            client, "execute_sql", {"query": query, "format": "csv"}
+        )
+    assert SECRET_PASSWORD not in output
+    assert SECRET_API_KEY not in output
+    assert MASK_PLACEHOLDER in output
+    assert "alice" in output, "non-sensitive columns must survive masking"
+
+
+async def test_masking_can_be_disabled(seed):
+    query = f"SELECT * FROM {CREDENTIALS_TABLE}"
+    async with stdio_session(**{"--mask-enabled": "false"}) as client:
+        output = await call_text(
+            client, "execute_sql", {"query": query, "format": "csv"}
+        )
+    assert SECRET_PASSWORD in output
+    assert SECRET_API_KEY in output
+
+
+PIPELINE_YAML = """processors:
+  - date:
+      field: time
+      formats:
+        - "%Y-%m-%d %H:%M:%S%.3f"
+      ignore_missing: true
+transform:
+  - fields:
+      - id
+    type: int32
+  - field: time
+    type: time
+    index: timestamp
+"""
+
+
+async def test_pipeline_lifecycle(seed):
+    name = "it_lifecycle_pipeline"
+    async with stdio_session() as client:
+        created = await call_text(
+            client, "create_pipeline", {"name": name, "pipeline": PIPELINE_YAML}
+        )
+        assert "created successfully" in created
+        version = created.rsplit("Version:", 1)[1].strip()
+
+        try:
+            listed = await call_text(client, "list_pipelines", {"name": name})
+            assert name in listed
+
+            dryrun = json.loads(
+                await call_text(
+                    client,
+                    "dryrun_pipeline",
+                    {
+                        "pipeline_name": name,
+                        "data": json.dumps(
+                            [{"id": 1, "time": "2024-05-25 20:16:37.217"}]
+                        ),
+                    },
+                )
+            )
+            assert dryrun[0]["rows"]
+        finally:
+            deleted = await call_text(
+                client, "delete_pipeline", {"name": name, "version": version}
+            )
+    assert "deleted successfully" in deleted
+
+
+async def test_dashboard_lifecycle(seed):
+    name = "it_lifecycle_dashboard"
+    definition = json.dumps(
+        {"kind": "Dashboard", "metadata": {"name": name}, "spec": {"panels": {}}}
+    )
+    async with stdio_session() as client:
+        created = await call_text(
+            client, "create_dashboard", {"name": name, "definition": definition}
+        )
+        assert "saved successfully" in created
+
+        try:
+            listed = json.loads(await call_text(client, "list_dashboards"))
+            assert any(d["name"] == name for d in listed["dashboards"])
+        finally:
+            deleted = await call_text(client, "delete_dashboard", {"name": name})
+    assert "deleted successfully" in deleted
+
+
+async def test_prompts_render(seed):
+    async with stdio_session() as client:
+        prompts = {prompt.name for prompt in (await client.list_prompts()).prompts}
+        assert "table_operation" in prompts
+        rendered = await client.get_prompt("table_operation", {"table": METRICS_TABLE})
+    assert METRICS_TABLE in rendered.messages[0].content.text

--- a/tests/integration/test_e2e.py
+++ b/tests/integration/test_e2e.py
@@ -1,8 +1,7 @@
 """Black-box tests: real MCP client -> real server subprocess -> real GreptimeDB.
 
-Each test opens its own stdio session. The session is entered inside the test
-body rather than in a fixture because unwinding anyio cancel scopes during
-pytest-asyncio fixture finalization happens on a different task and fails.
+Sessions are entered in the test body rather than in a fixture: anyio cancel
+scopes cannot be unwound from pytest-asyncio's finalization task.
 """
 
 import json
@@ -21,26 +20,6 @@ from .conftest import (
 )
 
 pytestmark = pytest.mark.integration
-
-
-async def test_tool_catalog(seed):
-    async with stdio_session() as client:
-        tools = {tool.name for tool in (await client.list_tools()).tools}
-    assert {
-        "execute_sql",
-        "describe_table",
-        "health_check",
-        "execute_tql",
-        "query_range",
-        "explain_query",
-        "list_pipelines",
-        "create_pipeline",
-        "dryrun_pipeline",
-        "delete_pipeline",
-        "list_dashboards",
-        "create_dashboard",
-        "delete_dashboard",
-    } <= tools
 
 
 async def test_health_check(seed):
@@ -140,14 +119,6 @@ async def test_describe_table(seed):
     assert profile["samples"]["rows"]
 
 
-async def test_describe_missing_table(seed):
-    async with stdio_session() as client:
-        profile = json.loads(
-            await call_text(client, "describe_table", {"table": "it_does_not_exist"})
-        )
-    assert "not found" in profile["error"]
-
-
 async def test_query_range(seed):
     async with stdio_session() as client:
         payload = json.loads(
@@ -189,15 +160,6 @@ async def test_execute_tql(seed):
     assert payload["tql"].startswith("TQL EVAL")
 
 
-async def test_explain_query(seed):
-    async with stdio_session() as client:
-        plan = await call_text(
-            client, "explain_query", {"query": f"SELECT * FROM {METRICS_TABLE}"}
-        )
-    assert "TableScan" in plan
-    assert METRICS_TABLE in plan
-
-
 async def test_explain_analyze_verbose_reports_metrics(seed):
     async with stdio_session() as client:
         plan = await call_text(
@@ -232,16 +194,6 @@ async def test_masking_hides_sensitive_columns(seed):
     assert "alice" in output, "non-sensitive columns must survive masking"
 
 
-async def test_masking_can_be_disabled(seed):
-    query = f"SELECT * FROM {CREDENTIALS_TABLE}"
-    async with stdio_session(**{"--mask-enabled": "false"}) as client:
-        output = await call_text(
-            client, "execute_sql", {"query": query, "format": "csv"}
-        )
-    assert SECRET_PASSWORD in output
-    assert SECRET_API_KEY in output
-
-
 PIPELINE_YAML = """processors:
   - date:
       field: time
@@ -264,7 +216,8 @@ async def test_pipeline_lifecycle(seed):
         created = await call_text(
             client, "create_pipeline", {"name": name, "pipeline": PIPELINE_YAML}
         )
-        assert "created successfully" in created
+        # Without a version the pipeline cannot be deleted, so it would leak.
+        assert "created successfully" in created and "Version:" in created
         version = created.rsplit("Version:", 1)[1].strip()
 
         try:

--- a/tests/integration/test_transport_e2e.py
+++ b/tests/integration/test_transport_e2e.py
@@ -1,9 +1,4 @@
-"""Black-box tests for the HTTP transport path.
-
-The stdio tests cover tool behaviour; these cover the parts that only exist
-when the server binds a socket -- transport settings, DNS rebinding protection,
-and the streamable-http session lifecycle.
-"""
+"""Black-box tests for the HTTP transport path."""
 
 import json
 
@@ -14,16 +9,7 @@ from .conftest import METRICS_TABLE, call_text, streamable_http_session
 pytestmark = pytest.mark.integration
 
 
-async def test_streamable_http_serves_tools(seed):
-    async with streamable_http_session() as client:
-        tools = {tool.name for tool in (await client.list_tools()).tools}
-        result = json.loads(await call_text(client, "health_check"))
-
-    assert "execute_sql" in tools
-    assert result["status"] == "healthy"
-
-
-async def test_streamable_http_executes_queries(seed):
+async def test_streamable_http_transport(seed):
     async with streamable_http_session() as client:
         payload = json.loads(
             await call_text(
@@ -39,7 +25,6 @@ async def test_streamable_http_executes_queries(seed):
 
 
 async def test_streamable_http_with_dns_rebinding_protection(seed):
-    """allowed-hosts turns on TransportSecuritySettings; requests must still pass."""
     async with streamable_http_session(
         **{"--allowed-hosts": "127.0.0.1:*,localhost:*"}
     ) as client:

--- a/tests/integration/test_transport_e2e.py
+++ b/tests/integration/test_transport_e2e.py
@@ -1,0 +1,47 @@
+"""Black-box tests for the HTTP transport path.
+
+The stdio tests cover tool behaviour; these cover the parts that only exist
+when the server binds a socket -- transport settings, DNS rebinding protection,
+and the streamable-http session lifecycle.
+"""
+
+import json
+
+import pytest
+
+from .conftest import METRICS_TABLE, call_text, streamable_http_session
+
+pytestmark = pytest.mark.integration
+
+
+async def test_streamable_http_serves_tools(seed):
+    async with streamable_http_session() as client:
+        tools = {tool.name for tool in (await client.list_tools()).tools}
+        result = json.loads(await call_text(client, "health_check"))
+
+    assert "execute_sql" in tools
+    assert result["status"] == "healthy"
+
+
+async def test_streamable_http_executes_queries(seed):
+    async with streamable_http_session() as client:
+        payload = json.loads(
+            await call_text(
+                client,
+                "execute_sql",
+                {
+                    "query": f"SELECT count(*) AS n FROM {METRICS_TABLE}",
+                    "format": "json",
+                },
+            )
+        )
+    assert payload["data"][0]["n"] == seed.row_count
+
+
+async def test_streamable_http_with_dns_rebinding_protection(seed):
+    """allowed-hosts turns on TransportSecuritySettings; requests must still pass."""
+    async with streamable_http_session(
+        **{"--allowed-hosts": "127.0.0.1:*,localhost:*"}
+    ) as client:
+        result = json.loads(await call_text(client, "health_check"))
+    assert result["status"] == "healthy"


### PR DESCRIPTION
Fixes #43.

## Stopgap: pin `mcp<2` (0.5.2)

SDK 2.0.0 removed `mcp.server.fastmcp`, which `server.py` imports. `pyproject.toml` only declared `mcp>=1.8.0`, so a fresh install resolved to 2.x and died at startup with `ModuleNotFoundError`.

SDK v1.x is now maintenance-only, so this is temporary — migration is tracked in #44.

New `install-smoke` job builds the wheel, installs it into a clean venv with fresh dependency resolution, then imports the server and runs the console script. Verified it catches this class of failure: installing `mcp==2.0.0` into that venv reproduces the error.

## Black-box integration CI

Every existing test mocks `mysql.connector`, so nothing verified the server starts, speaks MCP, or returns correct results. That gap blocks #44, which rewrites transport setup and lifespan handling — a broken `run()` would pass the entire mock suite.

A real MCP client now drives a real server subprocess against GreptimeDB `v1.2.0-beta.1` in Docker. 17 cases over stdio and streamable-http: queries in all three formats, row-limit truncation, the security gate (checked against actual database state, not the response string), write mode, table profiling, RANGE and TQL, `EXPLAIN ANALYZE VERBOSE`, resource reads, masking, pipeline and dashboard lifecycles over the HTTP API, prompt rendering, and DNS rebinding protection.

Audit logging stays enabled in these tests on purpose: `_install_audit_hook` monkey-patches the SDK's private tool manager and its signature must match `ToolManager.call_tool` exactly, which makes it the most fragile thing here for the 2.x migration.

Seed data is loaded over a direct MySQL connection, not through the server, so a broken server cannot make its own fixtures pass. Marked `integration` and deselected by default — plain `pytest` is unchanged.

## Verification

Against `greptime/greptimedb:v1.2.0-beta.1`: `pytest -m integration` 17 passed, `pytest` 188 passed / 17 deselected, `black --check .` clean, flake8 clean, clean-venv wheel install OK.

Two real constraints surfaced that mock tests could not have found: `password` is a reserved word in GreptimeDB's parser, and `greptime_private.pipelines` does not exist until the first pipeline is created.
