### PR TITLE
feat: migrate to MCP Python SDK 2.x

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -55,7 +55,7 @@ jobs:
         VIRTUAL_ENV=/tmp/smoke uv pip install dist/*.whl
     - name: Import smoke test
       run: |
-        /tmp/smoke/bin/python -c "from mcp.server.fastmcp import FastMCP; import greptimedb_mcp_server.server"
+        /tmp/smoke/bin/python -c "from mcp.server.mcpserver import MCPServer; import greptimedb_mcp_server.server"
         /tmp/smoke/bin/greptimedb-mcp-server --help
 
   # Uses `docker run` rather than `services:` because the image needs a

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ greptimedb-mcp-server \
 
 ### HTTP Server Mode
 
-For containerized or Kubernetes deployments. Requires `mcp>=1.8.0,<2`:
+For containerized or Kubernetes deployments:
 
 ```bash
 # Streamable HTTP (recommended for production)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,13 +4,13 @@ build-backend = "hatchling.build"
 
 [project]
 name = "greptimedb-mcp-server"
-version = "0.5.2"
+version = "0.6.0"
 description = "MCP server for GreptimeDB with SQL/TQL/PromQL support, sensitive data masking, and prompt templates for observability data analysis."
 readme = "README.md"
 license = {text = "MIT"}
 requires-python = ">=3.11"
 dependencies = [
-    "mcp>=1.8.0,<2",
+    "mcp>=2.1.1,<3",
     "mysql-connector-python>=9.7.0",
     "pyyaml>=6.0.2",
     "aiohttp>=3.9.0",

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/GreptimeTeam/greptimedb-mcp-server",
     "source": "github"
   },
-  "version": "0.5.2",
+  "version": "0.6.0",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "greptimedb-mcp-server",
-      "version": "0.5.2",
+      "version": "0.6.0",
       "transport": {
         "type": "stdio"
       },

--- a/src/greptimedb_mcp_server/server.py
+++ b/src/greptimedb_mcp_server/server.py
@@ -1,4 +1,4 @@
-"""GreptimeDB MCP Server using FastMCP API."""
+"""GreptimeDB MCP Server built on the MCP Python SDK v2 MCPServer API."""
 
 import asyncio
 import sys
@@ -24,6 +24,7 @@ from greptimedb_mcp_server.utils import (
     render_prompt_template,
 )
 
+import functools
 import json
 import logging
 import re
@@ -35,8 +36,9 @@ from typing import Annotated
 from urllib.parse import quote
 
 import aiohttp
-from mcp.server.fastmcp import FastMCP
-from mcp.server.fastmcp.server import TransportSecuritySettings
+from mcp.server.mcpserver import MCPServer
+from mcp.server.mcpserver.exceptions import ResourceError, ToolError
+from mcp.server.transport_security import TransportSecuritySettings
 from mysql.connector import connect, Error
 from mysql.connector.pooling import MySQLConnectionPool
 
@@ -395,7 +397,7 @@ def _build_table_guidance(schema: dict, semantics: dict, samples: dict) -> list[
 
 
 @asynccontextmanager
-async def lifespan(mcp: FastMCP):
+async def lifespan(mcp: MCPServer):
     """Initialize application state on startup."""
     global _state
 
@@ -453,11 +455,55 @@ async def lifespan(mcp: FastMCP):
             await _state.http_session.close()
 
 
-mcp = FastMCP(
+mcp = MCPServer(
     "greptimedb_mcp_server",
     instructions="GreptimeDB MCP Server - provides secure read-only access to GreptimeDB",
     lifespan=lifespan,
 )
+
+
+def _audit(
+    name: str, arguments: dict, start_time: float, error: Exception | None = None
+) -> None:
+    if _config is None or not _config.audit_enabled:
+        return
+    audit_log(
+        name,
+        arguments,
+        success=error is None,
+        duration_ms=(time.time() - start_time) * 1000,
+        error=str(error) if error is not None else None,
+    )
+
+
+def tool(**tool_kwargs):
+    """Register an async tool, adding audit logging and error translation.
+
+    The SDK reports any exception that is not a `ToolError` with a generic
+    message, so validation failures are re-raised as `ToolError` to keep the
+    reason visible to the client.
+    """
+
+    def decorator(fn):
+        @functools.wraps(fn)
+        async def wrapper(**arguments):
+            start_time = time.time()
+            try:
+                result = await fn(**arguments)
+            except ValueError as e:
+                _audit(fn.__name__, arguments, start_time, e)
+                raise ToolError(str(e)) from e
+            except Exception as e:
+                _audit(fn.__name__, arguments, start_time, e)
+                raise
+            _audit(fn.__name__, arguments, start_time)
+            return result
+
+        mcp.tool(**tool_kwargs)(wrapper)
+        return wrapper
+
+    return decorator
+
 
 # Query type constants
 _READ_COMMANDS = ("SELECT", "SHOW", "DESC", "TQL", "EXPLAIN", "WITH")
@@ -549,7 +595,7 @@ def _execute_query(state: AppState, query: str, limit: int) -> dict:
             return {"type": "modify", "rowcount": cursor.rowcount}
 
 
-@mcp.tool()
+@tool()
 async def execute_sql(
     query: Annotated[str, "The SQL query to execute (using MySQL dialect)"],
     format: Annotated[
@@ -583,7 +629,7 @@ async def execute_sql(
         return f"Error executing query: {str(e)}"
 
 
-@mcp.tool()
+@tool()
 async def describe_table(
     table: Annotated[
         str,
@@ -673,7 +719,7 @@ async def describe_table(
         )
 
 
-@mcp.tool()
+@tool()
 async def health_check() -> str:
     """Check GreptimeDB connection status and server version."""
     state = get_state()
@@ -712,7 +758,7 @@ async def health_check() -> str:
         return json.dumps(result, indent=2)
 
 
-@mcp.tool()
+@tool()
 async def execute_tql(
     query: Annotated[
         str,
@@ -797,7 +843,7 @@ async def execute_tql(
         return f"Error executing TQL: {str(e)}"
 
 
-@mcp.tool()
+@tool()
 async def query_range(
     table: Annotated[str, "Table name to query (supports schema.table format)"],
     select: Annotated[
@@ -891,7 +937,7 @@ async def query_range(
         return f"Error executing range query: {str(e)}"
 
 
-@mcp.tool()
+@tool()
 async def explain_query(
     query: Annotated[str, "SQL or TQL query to analyze"],
     analyze: Annotated[bool, "Execute and show actual metrics"] = False,
@@ -958,7 +1004,11 @@ async def explain_query(
 async def read_table_resource(table: str) -> str:
     """Read table contents (limited to 100 rows)."""
     state = get_state()
-    table = validate_table_name(table)
+    try:
+        table = validate_table_name(table)
+    except ValueError as e:
+        # Same reason as in `tool()`: only a ResourceError keeps its message.
+        raise ResourceError(str(e)) from e
 
     def _sync_read_table():
         with state.get_connection() as conn:
@@ -978,7 +1028,7 @@ async def read_table_resource(table: str) -> str:
         return await asyncio.to_thread(_sync_read_table)
     except Error as e:
         logger.error(f"Database error reading table {table}: {str(e)}")
-        raise RuntimeError(f"Database error: {str(e)}")
+        raise ResourceError(f"Database error: {str(e)}") from e
 
 
 PIPELINE_NAME_PATTERN = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*$")
@@ -1004,7 +1054,7 @@ def _format_pipeline_version(ns_timestamp: int) -> str:
     return f"{dt.strftime('%Y-%m-%d %H:%M:%S')}.{nanoseconds:09d}"
 
 
-@mcp.tool()
+@tool()
 async def list_pipelines(
     name: Annotated[str | None, "Optional pipeline name to filter by"] = None,
 ) -> str:
@@ -1059,7 +1109,7 @@ async def list_pipelines(
         return f"Error listing pipelines: {str(e)}"
 
 
-@mcp.tool()
+@tool()
 async def create_pipeline(
     name: Annotated[str, "Name of the pipeline to create"],
     pipeline: Annotated[str, "Pipeline configuration in YAML format"],
@@ -1101,7 +1151,7 @@ async def create_pipeline(
         return f"Error creating pipeline: {str(e)}"
 
 
-@mcp.tool()
+@tool()
 async def dryrun_pipeline(
     pipeline: Annotated[
         str | None,
@@ -1185,7 +1235,7 @@ async def dryrun_pipeline(
         return f"Error testing pipeline: {str(e)}"
 
 
-@mcp.tool()
+@tool()
 async def delete_pipeline(
     name: Annotated[str, "Name of the pipeline to delete"],
     version: Annotated[str, "Version of the pipeline to delete (timestamp)"],
@@ -1232,7 +1282,7 @@ def _validate_dashboard_name(name: str) -> str:
     return name
 
 
-@mcp.tool()
+@tool()
 async def list_dashboards() -> str:
     """List all Perses dashboard definitions stored in GreptimeDB."""
     state = get_state()
@@ -1260,7 +1310,7 @@ async def list_dashboards() -> str:
         return f"Error listing dashboards: {str(e)}"
 
 
-@mcp.tool()
+@tool()
 async def create_dashboard(
     name: Annotated[str, "Name of the dashboard"],
     definition: Annotated[str, "Perses dashboard definition in JSON format"],
@@ -1298,7 +1348,7 @@ async def create_dashboard(
         return f"Error creating dashboard: {str(e)}"
 
 
-@mcp.tool()
+@tool()
 async def delete_dashboard(
     name: Annotated[str, "Name of the dashboard to delete"],
 ) -> str:
@@ -1383,25 +1433,28 @@ def prompt_fn({arg_params}) -> str:
 _register_prompts()
 
 
-def _install_audit_hook():
-    """Install audit logging hook by wrapping tool manager's call_tool method."""
-    original_call_tool = mcp._tool_manager.call_tool
+def _transport_security(config: Config) -> TransportSecuritySettings:
+    """Build DNS rebinding protection settings.
 
-    async def audited_call_tool(name, arguments, context=None, convert_result=False):
-        start_time = time.time()
-        try:
-            result = await original_call_tool(name, arguments, context, convert_result)
-            elapsed_ms = (time.time() - start_time) * 1000
-            audit_log(name, arguments, success=True, duration_ms=elapsed_ms)
-            return result
-        except Exception as e:
-            elapsed_ms = (time.time() - start_time) * 1000
-            audit_log(
-                name, arguments, success=False, duration_ms=elapsed_ms, error=str(e)
-            )
-            raise
+    An empty allowed_hosts disables protection, for compatibility with proxies,
+    gateways, and Kubernetes services.
+    """
+    if not config.allowed_hosts:
+        logger.info("DNS rebinding protection: disabled")
+        return TransportSecuritySettings(enable_dns_rebinding_protection=False)
 
-    mcp._tool_manager.call_tool = audited_call_tool
+    kwargs = {
+        "enable_dns_rebinding_protection": True,
+        "allowed_hosts": config.allowed_hosts,
+    }
+    if config.allowed_origins:
+        kwargs["allowed_origins"] = config.allowed_origins
+    logger.info(
+        f"DNS rebinding protection: enabled "
+        f"(allowed_hosts: {config.allowed_hosts}, "
+        f"allowed_origins: {config.allowed_origins or 'default'})"
+    )
+    return TransportSecuritySettings(**kwargs)
 
 
 def main():
@@ -1409,51 +1462,23 @@ def main():
     global _config
     _config = Config.from_env_arguments()
 
-    # Install audit logging hook if enabled
-    if _config.audit_enabled:
-        _install_audit_hook()
-        logger.info("Audit logging: enabled")
-    else:
-        logger.info("Audit logging: disabled")
+    logger.info(f"Audit logging: {'enabled' if _config.audit_enabled else 'disabled'}")
 
-    # Only configure HTTP server settings for non-stdio transports
-    # to avoid overriding user's programmatic configuration
-    if _config.transport != "stdio":
-        mcp.settings.host = _config.listen_host
-        mcp.settings.port = _config.listen_port
-
-        # Configure DNS rebinding protection
-        # If allowed_hosts is empty, disable protection for compatibility
-        # with proxies, gateways, and Kubernetes services
-        if _config.allowed_hosts:
-            security_kwargs = {
-                "enable_dns_rebinding_protection": True,
-                "allowed_hosts": _config.allowed_hosts,
-            }
-            if _config.allowed_origins:
-                security_kwargs["allowed_origins"] = _config.allowed_origins
-            mcp.settings.transport_security = TransportSecuritySettings(
-                **security_kwargs
-            )
-            logger.info(
-                f"DNS rebinding protection: enabled "
-                f"(allowed_hosts: {_config.allowed_hosts}, "
-                f"allowed_origins: {_config.allowed_origins or 'default'})"
-            )
-        else:
-            mcp.settings.transport_security = TransportSecuritySettings(
-                enable_dns_rebinding_protection=False,
-            )
-            logger.info("DNS rebinding protection: disabled")
-
-        logger.info(
-            f"Starting MCP server with transport: {_config.transport} "
-            f"on {_config.listen_host}:{_config.listen_port}"
-        )
-    else:
+    if _config.transport == "stdio":
         logger.info("Starting MCP server with transport: stdio")
+        mcp.run()
+        return
 
-    mcp.run(transport=_config.transport)
+    logger.info(
+        f"Starting MCP server with transport: {_config.transport} "
+        f"on {_config.listen_host}:{_config.listen_port}"
+    )
+    mcp.run(
+        transport=_config.transport,
+        host=_config.listen_host,
+        port=_config.listen_port,
+        transport_security=_transport_security(_config),
+    )
 
 
 if __name__ == "__main__":

--- a/src/greptimedb_mcp_server/server.py
+++ b/src/greptimedb_mcp_server/server.py
@@ -485,18 +485,22 @@ def tool(**tool_kwargs):
     """
 
     def decorator(fn):
+        # The audited subject is the name the client called, which is the
+        # registered name rather than the function's.
+        name = tool_kwargs.get("name") or fn.__name__
+
         @functools.wraps(fn)
         async def wrapper(**arguments):
             start_time = time.time()
             try:
                 result = await fn(**arguments)
             except ValueError as e:
-                _audit(fn.__name__, arguments, start_time, e)
+                _audit(name, arguments, start_time, e)
                 raise ToolError(str(e)) from e
             except Exception as e:
-                _audit(fn.__name__, arguments, start_time, e)
+                _audit(name, arguments, start_time, e)
                 raise
-            _audit(fn.__name__, arguments, start_time)
+            _audit(name, arguments, start_time)
             return result
 
         mcp.tool(**tool_kwargs)(wrapper)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -18,7 +18,7 @@ import mysql.connector
 import pytest
 from mcp import ClientSession, StdioServerParameters
 from mcp.client.stdio import stdio_client
-from mcp.client.streamable_http import streamablehttp_client
+from mcp.client.streamable_http import streamable_http_client
 
 HOST = os.getenv("GREPTIMEDB_IT_HOST", "127.0.0.1")
 MYSQL_PORT = int(os.getenv("GREPTIMEDB_IT_PORT", "4002"))
@@ -120,8 +120,8 @@ def seed(db):
 def server_argv(**overrides) -> list[str]:
     """Build the CLI argv for a server subprocess pointed at the test instance.
 
-    Audit logging is left enabled on purpose: it monkey-patches the SDK's private
-    tool manager, so every tool call here also proves that hook still works.
+    Audit logging is left enabled on purpose, so every tool call here also
+    exercises the audit path wrapped around each tool.
     """
     flags = {
         "--host": HOST,
@@ -183,10 +183,9 @@ async def streamable_http_session(**overrides):
     )
     try:
         _wait_for_port(port)
-        async with streamablehttp_client(f"http://127.0.0.1:{port}/mcp") as (
+        async with streamable_http_client(f"http://127.0.0.1:{port}/mcp") as (
             read,
             write,
-            _,
         ):
             async with ClientSession(read, write) as session:
                 await session.initialize()

--- a/tests/integration/test_e2e.py
+++ b/tests/integration/test_e2e.py
@@ -7,7 +7,7 @@ scopes cannot be unwound from pytest-asyncio's finalization task.
 import json
 
 import pytest
-from pydantic import AnyUrl
+from mcp import MCPError
 
 from .conftest import (
     CREDENTIALS_TABLE,
@@ -174,9 +174,24 @@ async def test_explain_analyze_verbose_reports_metrics(seed):
     assert "output_rows" in plan
 
 
+async def test_invalid_argument_reports_the_reason(seed):
+    """The SDK reports a plain exception with a generic message, so the tool
+    and resource wrappers must translate validation failures."""
+    async with stdio_session() as client:
+        result = await client.call_tool(
+            "execute_sql", {"query": "SELECT 1", "format": "xml"}
+        )
+        assert result.is_error
+        assert "Invalid format" in result.content[0].text
+
+        with pytest.raises(MCPError) as excinfo:
+            await client.read_resource("greptime://123invalid/data")
+        assert "Invalid table name" in str(excinfo.value)
+
+
 async def test_read_table_resource(seed):
     async with stdio_session() as client:
-        result = await client.read_resource(AnyUrl(f"greptime://{METRICS_TABLE}/data"))
+        result = await client.read_resource(f"greptime://{METRICS_TABLE}/data")
     body = result.contents[0].text
     assert body.splitlines()[0] == "ts,host,cpu"
     assert len(body.splitlines()) == seed.row_count + 1

--- a/tests/test_http_transport.py
+++ b/tests/test_http_transport.py
@@ -7,7 +7,7 @@ import socket
 from contextlib import closing
 from unittest.mock import patch
 
-import httpx
+import httpx2
 
 
 def find_free_port() -> int:
@@ -54,22 +54,22 @@ class TestStreamableHttpTransport:
         self, free_port, mock_db_connection
     ):
         """Test that initialize request returns valid MCP protocol response."""
-        from mcp.server.fastmcp import FastMCP
+        from mcp.server.mcpserver import MCPServer
 
-        test_mcp = FastMCP("test_server", host="127.0.0.1", port=free_port)
+        test_mcp = MCPServer("test_server")
 
         @test_mcp.tool()
         def ping() -> str:
             return "pong"
 
         async def run_server():
-            await test_mcp.run_streamable_http_async()
+            await test_mcp.run_streamable_http_async(host="127.0.0.1", port=free_port)
 
         server_task = asyncio.create_task(run_server())
         await asyncio.sleep(0.5)
 
         try:
-            async with httpx.AsyncClient(trust_env=False) as client:
+            async with httpx2.AsyncClient(trust_env=False) as client:
                 response = await client.post(
                     f"http://127.0.0.1:{free_port}/mcp",
                     json={
@@ -122,18 +122,18 @@ class TestStreamableHttpTransport:
         self, free_port, mock_db_connection
     ):
         """Test that /mcp endpoint returns error for invalid JSON."""
-        from mcp.server.fastmcp import FastMCP
+        from mcp.server.mcpserver import MCPServer
 
-        test_mcp = FastMCP("test_server", host="127.0.0.1", port=free_port)
+        test_mcp = MCPServer("test_server")
 
         async def run_server():
-            await test_mcp.run_streamable_http_async()
+            await test_mcp.run_streamable_http_async(host="127.0.0.1", port=free_port)
 
         server_task = asyncio.create_task(run_server())
         await asyncio.sleep(0.5)
 
         try:
-            async with httpx.AsyncClient(trust_env=False) as client:
+            async with httpx2.AsyncClient(trust_env=False) as client:
                 response = await client.post(
                     f"http://127.0.0.1:{free_port}/mcp",
                     content=b"not valid json",
@@ -161,18 +161,18 @@ class TestSseTransport:
         self, free_port, mock_db_connection
     ):
         """Test that /sse endpoint returns SSE event with messages endpoint."""
-        from mcp.server.fastmcp import FastMCP
+        from mcp.server.mcpserver import MCPServer
 
-        test_mcp = FastMCP("test_server", host="127.0.0.1", port=free_port)
+        test_mcp = MCPServer("test_server")
 
         async def run_server():
-            await test_mcp.run_sse_async()
+            await test_mcp.run_sse_async(host="127.0.0.1", port=free_port)
 
         server_task = asyncio.create_task(run_server())
         await asyncio.sleep(0.5)
 
         try:
-            async with httpx.AsyncClient(trust_env=False) as client:
+            async with httpx2.AsyncClient(trust_env=False) as client:
                 async with client.stream(
                     "GET", f"http://127.0.0.1:{free_port}/sse", timeout=2.0
                 ) as response:
@@ -190,7 +190,7 @@ class TestSseTransport:
 
                     # Verify endpoint URL is provided
                     assert "/messages/" in event_data
-        except httpx.ReadTimeout:
+        except httpx2.ReadTimeout:
             pass  # SSE stream stays open, timeout is expected
         finally:
             server_task.cancel()
@@ -204,18 +204,18 @@ class TestSseTransport:
         self, free_port, mock_db_connection
     ):
         """Test that /messages/ endpoint rejects requests without valid session."""
-        from mcp.server.fastmcp import FastMCP
+        from mcp.server.mcpserver import MCPServer
 
-        test_mcp = FastMCP("test_server", host="127.0.0.1", port=free_port)
+        test_mcp = MCPServer("test_server")
 
         async def run_server():
-            await test_mcp.run_sse_async()
+            await test_mcp.run_sse_async(host="127.0.0.1", port=free_port)
 
         server_task = asyncio.create_task(run_server())
         await asyncio.sleep(0.5)
 
         try:
-            async with httpx.AsyncClient(trust_env=False) as client:
+            async with httpx2.AsyncClient(trust_env=False) as client:
                 response = await client.post(
                     f"http://127.0.0.1:{free_port}/messages/",
                     json={"jsonrpc": "2.0", "id": 1, "method": "ping"},
@@ -268,24 +268,26 @@ class TestDnsRebindingProtection:
     @pytest.mark.asyncio
     async def test_protection_disabled_by_default(self, free_port, mock_db_connection):
         """Test that DNS rebinding protection is disabled when allowed_hosts is empty."""
-        from mcp.server.fastmcp import FastMCP
-        from mcp.server.fastmcp.server import TransportSecuritySettings
+        from mcp.server.mcpserver import MCPServer
+        from mcp.server.transport_security import TransportSecuritySettings
 
-        test_mcp = FastMCP("test_server", host="127.0.0.1", port=free_port)
+        test_mcp = MCPServer("test_server")
 
         # Simulate our server.py logic: empty allowed_hosts = disabled
-        test_mcp.settings.transport_security = TransportSecuritySettings(
+        security = TransportSecuritySettings(
             enable_dns_rebinding_protection=False,
         )
 
         async def run_server():
-            await test_mcp.run_streamable_http_async()
+            await test_mcp.run_streamable_http_async(
+                host="127.0.0.1", port=free_port, transport_security=security
+            )
 
         server_task = asyncio.create_task(run_server())
         await asyncio.sleep(0.5)
 
         try:
-            async with httpx.AsyncClient(trust_env=False) as client:
+            async with httpx2.AsyncClient(trust_env=False) as client:
                 # Request with arbitrary Host header should succeed
                 response = await client.post(
                     f"http://127.0.0.1:{free_port}/mcp",
@@ -320,25 +322,27 @@ class TestDnsRebindingProtection:
         self, free_port, mock_db_connection
     ):
         """Test that enabled protection rejects requests with invalid Host header."""
-        from mcp.server.fastmcp import FastMCP
-        from mcp.server.fastmcp.server import TransportSecuritySettings
+        from mcp.server.mcpserver import MCPServer
+        from mcp.server.transport_security import TransportSecuritySettings
 
-        test_mcp = FastMCP("test_server", host="127.0.0.1", port=free_port)
+        test_mcp = MCPServer("test_server")
 
         # Enable protection with specific allowed hosts
-        test_mcp.settings.transport_security = TransportSecuritySettings(
+        security = TransportSecuritySettings(
             enable_dns_rebinding_protection=True,
             allowed_hosts=["localhost:*", "127.0.0.1:*"],
         )
 
         async def run_server():
-            await test_mcp.run_streamable_http_async()
+            await test_mcp.run_streamable_http_async(
+                host="127.0.0.1", port=free_port, transport_security=security
+            )
 
         server_task = asyncio.create_task(run_server())
         await asyncio.sleep(0.5)
 
         try:
-            async with httpx.AsyncClient(trust_env=False) as client:
+            async with httpx2.AsyncClient(trust_env=False) as client:
                 # Request with disallowed Host header should be rejected
                 response = await client.post(
                     f"http://127.0.0.1:{free_port}/mcp",

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,5 +1,7 @@
 import pytest
 import json
+import logging
+from dataclasses import replace
 
 from mcp.server.mcpserver.exceptions import ResourceError, ToolError
 
@@ -1106,3 +1108,21 @@ async def test_delete_dashboard_invalid_name():
     with pytest.raises(ToolError) as excinfo:
         await delete_dashboard(name="123.invalid")
     assert "Invalid dashboard name" in str(excinfo.value)
+
+
+@pytest.mark.asyncio
+async def test_audit_uses_registered_tool_name(caplog):
+    """Audit records the name the client called, not the function's."""
+    server._config = replace(server._config, audit_enabled=True)
+
+    @server.tool(name="renamed_tool")
+    async def original_name() -> str:
+        return "ok"
+
+    try:
+        with caplog.at_level(logging.INFO, logger="greptimedb_mcp_server.audit"):
+            await original_name()
+    finally:
+        server.mcp.remove_tool("renamed_tool")
+
+    assert "[AUDIT] renamed_tool" in caplog.text

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,6 +1,8 @@
 import pytest
 import json
 
+from mcp.server.mcpserver.exceptions import ResourceError, ToolError
+
 from greptimedb_mcp_server.config import Config
 from greptimedb_mcp_server import server
 from greptimedb_mcp_server.server import (
@@ -159,7 +161,7 @@ async def test_execute_sql_markdown_format():
 @pytest.mark.asyncio
 async def test_execute_sql_missing_query():
     """Test execute_sql with missing query parameter"""
-    with pytest.raises(ValueError) as excinfo:
+    with pytest.raises(ToolError) as excinfo:
         await execute_sql(query="")
     assert "Query is required" in str(excinfo.value)
 
@@ -167,7 +169,7 @@ async def test_execute_sql_missing_query():
 @pytest.mark.asyncio
 async def test_execute_sql_invalid_format():
     """Test execute_sql with invalid format parameter"""
-    with pytest.raises(ValueError) as excinfo:
+    with pytest.raises(ToolError) as excinfo:
         await execute_sql(query="SELECT 1", format="xml")
     assert "Invalid format" in str(excinfo.value)
 
@@ -430,7 +432,7 @@ async def test_describe_table_not_found():
 @pytest.mark.asyncio
 async def test_describe_table_invalid_name():
     """Test describe_table with invalid table name"""
-    with pytest.raises(ValueError) as excinfo:
+    with pytest.raises(ToolError) as excinfo:
         await describe_table(table="123invalid")
     assert "Invalid table name" in str(excinfo.value)
 
@@ -438,7 +440,7 @@ async def test_describe_table_invalid_name():
 @pytest.mark.asyncio
 async def test_describe_table_missing_table():
     """Test describe_table with missing table parameter"""
-    with pytest.raises(ValueError) as excinfo:
+    with pytest.raises(ToolError) as excinfo:
         await describe_table(table="")
     assert "Table name is required" in str(excinfo.value)
 
@@ -492,7 +494,7 @@ async def test_execute_tql_with_lookback():
 @pytest.mark.asyncio
 async def test_execute_tql_missing_params():
     """Test execute_tql with missing required parameters"""
-    with pytest.raises(ValueError) as excinfo:
+    with pytest.raises(ToolError) as excinfo:
         await execute_tql(query="rate(x[5m])", start="", end="", step="")
     assert "required" in str(excinfo.value)
 
@@ -500,7 +502,7 @@ async def test_execute_tql_missing_params():
 @pytest.mark.asyncio
 async def test_execute_tql_injection_blocked():
     """Test execute_tql blocks injection in parameters"""
-    with pytest.raises(ValueError) as excinfo:
+    with pytest.raises(ToolError) as excinfo:
         await execute_tql(
             query="rate(x[5m])",
             start="2024-01-01'; DROP TABLE users; --",
@@ -583,7 +585,7 @@ async def test_query_range_with_by():
 @pytest.mark.asyncio
 async def test_query_range_invalid_table():
     """Test query_range with invalid table name"""
-    with pytest.raises(ValueError) as excinfo:
+    with pytest.raises(ToolError) as excinfo:
         await query_range(table="123-bad", select="ts, avg(cpu)", align="1m")
     assert "Invalid table name" in str(excinfo.value)
 
@@ -591,7 +593,7 @@ async def test_query_range_invalid_table():
 @pytest.mark.asyncio
 async def test_query_range_missing_params():
     """Test query_range with missing required parameters"""
-    with pytest.raises(ValueError) as excinfo:
+    with pytest.raises(ToolError) as excinfo:
         await query_range(table="metrics", select="", align="")
     assert "required" in str(excinfo.value)
 
@@ -599,7 +601,7 @@ async def test_query_range_missing_params():
 @pytest.mark.asyncio
 async def test_query_range_injection_blocked():
     """Test query_range blocks injection in where clause"""
-    with pytest.raises(ValueError) as excinfo:
+    with pytest.raises(ToolError) as excinfo:
         await query_range(
             table="metrics",
             select="ts, avg(cpu)",
@@ -612,7 +614,7 @@ async def test_query_range_injection_blocked():
 @pytest.mark.asyncio
 async def test_query_range_align_injection_blocked():
     """Test query_range blocks injection in align parameter"""
-    with pytest.raises(ValueError) as excinfo:
+    with pytest.raises(ToolError) as excinfo:
         await query_range(
             table="metrics",
             select="ts, avg(cpu)",
@@ -624,7 +626,7 @@ async def test_query_range_align_injection_blocked():
 @pytest.mark.asyncio
 async def test_query_range_invalid_align():
     """Test query_range rejects invalid duration format"""
-    with pytest.raises(ValueError) as excinfo:
+    with pytest.raises(ToolError) as excinfo:
         await query_range(
             table="metrics",
             select="ts, avg(cpu)",
@@ -636,7 +638,7 @@ async def test_query_range_invalid_align():
 @pytest.mark.asyncio
 async def test_query_range_fill_injection_blocked():
     """Test query_range blocks injection in fill parameter"""
-    with pytest.raises(ValueError) as excinfo:
+    with pytest.raises(ToolError) as excinfo:
         await query_range(
             table="metrics",
             select="ts, avg(cpu)",
@@ -684,7 +686,7 @@ async def test_explain_query_with_analyze():
 @pytest.mark.asyncio
 async def test_explain_query_missing_query():
     """Test explain_query with missing query parameter"""
-    with pytest.raises(ValueError) as excinfo:
+    with pytest.raises(ToolError) as excinfo:
         await explain_query(query="")
     assert "query is required" in str(excinfo.value)
 
@@ -754,7 +756,7 @@ async def test_read_table_resource():
 @pytest.mark.asyncio
 async def test_read_table_resource_invalid_name():
     """Test read_table_resource with invalid table name"""
-    with pytest.raises(ValueError) as excinfo:
+    with pytest.raises(ResourceError) as excinfo:
         await read_table_resource(table="123invalid")
     assert "Invalid table name" in str(excinfo.value)
 
@@ -902,7 +904,7 @@ async def test_execute_tql_csv_format():
 @pytest.mark.asyncio
 async def test_execute_tql_invalid_format():
     """Test execute_tql with invalid format parameter"""
-    with pytest.raises(ValueError) as excinfo:
+    with pytest.raises(ToolError) as excinfo:
         await execute_tql(
             query="rate(x[5m])",
             start="2024-01-01T00:00:00Z",
@@ -929,7 +931,7 @@ async def test_query_range_csv_format():
 @pytest.mark.asyncio
 async def test_query_range_invalid_format():
     """Test query_range with invalid format parameter"""
-    with pytest.raises(ValueError) as excinfo:
+    with pytest.raises(ToolError) as excinfo:
         await query_range(
             table="metrics",
             select="ts, avg(cpu)",
@@ -1000,7 +1002,7 @@ async def test_list_pipelines_with_name():
 @pytest.mark.asyncio
 async def test_create_pipeline_invalid_name():
     """Test create_pipeline with invalid name"""
-    with pytest.raises(ValueError) as excinfo:
+    with pytest.raises(ToolError) as excinfo:
         await create_pipeline(name="123-invalid", pipeline="version: 2")
     assert "Invalid pipeline name" in str(excinfo.value)
 
@@ -1008,7 +1010,7 @@ async def test_create_pipeline_invalid_name():
 @pytest.mark.asyncio
 async def test_dryrun_pipeline_invalid_pipeline_name():
     """Test dryrun_pipeline with invalid pipeline name"""
-    with pytest.raises(ValueError) as excinfo:
+    with pytest.raises(ToolError) as excinfo:
         await dryrun_pipeline(pipeline_name="123-invalid", data='{"message": "test"}')
     assert "Invalid pipeline name" in str(excinfo.value)
 
@@ -1039,7 +1041,7 @@ async def test_dryrun_pipeline_neither_pipeline_nor_name():
 @pytest.mark.asyncio
 async def test_delete_pipeline_invalid_name():
     """Test delete_pipeline with invalid name"""
-    with pytest.raises(ValueError) as excinfo:
+    with pytest.raises(ToolError) as excinfo:
         await delete_pipeline(name="123-invalid", version="2024-01-01")
     assert "Invalid pipeline name" in str(excinfo.value)
 
@@ -1086,7 +1088,7 @@ def test_validate_dashboard_name_invalid():
 @pytest.mark.asyncio
 async def test_create_dashboard_invalid_name():
     """Test create_dashboard with invalid name"""
-    with pytest.raises(ValueError) as excinfo:
+    with pytest.raises(ToolError) as excinfo:
         await create_dashboard(name="123.invalid", definition='{"kind": "Dashboard"}')
     assert "Invalid dashboard name" in str(excinfo.value)
 
@@ -1101,6 +1103,6 @@ async def test_create_dashboard_invalid_json():
 @pytest.mark.asyncio
 async def test_delete_dashboard_invalid_name():
     """Test delete_dashboard with invalid name"""
-    with pytest.raises(ValueError) as excinfo:
+    with pytest.raises(ToolError) as excinfo:
         await delete_dashboard(name="123.invalid")
     assert "Invalid dashboard name" in str(excinfo.value)


### PR DESCRIPTION
Closes #44.

SDK v1 entered maintenance mode on 2026-07-28 and only receives security fixes. `mcp.server.fastmcp` is a tombstone module in v2, so this bumps the pin to `mcp>=2.1.1,<3` and ports `FastMCP` to `MCPServer`. Existing users who need v1 stay on 0.5.2.

## Changes

- `FastMCP` → `MCPServer`; `TransportSecuritySettings` moved to `mcp.server.transport_security`.
- `host`, `port` and `transport_security` moved off the constructor onto `run()`; `mcp.settings` no longer exists.
- Tools are registered through a `tool()` decorator that translates `ValueError` into `ToolError`, and the table resource raises `ResourceError`. v2 replaces the message of any exception that is not a `ToolError`/`ResourceError` with a generic string, so without this an invalid `format` reached the client as `Error executing tool execute_sql` instead of `Invalid format: xml. Must be one of: ...`.
- Audit logging moved into that decorator. It previously monkey-patched the SDK's private `_tool_manager.call_tool`. Audit lines now include arguments left at their defaults.
- `httpx` → `httpx2` in the transport tests (v2 depends on `httpx2`), `streamablehttp_client` → `streamable_http_client` (two-tuple instead of three), `read_resource()` takes a `str` instead of an `AnyUrl`.
- Version bumped to 0.6.0.

Two points in the issue turned out to be wrong:

- v2 still validates tool arguments against the generated pydantic model (`{"limit": "abc"}` is rejected, extra keys ignored), so `_validate_sql_params` needs no change.
- The error-semantics change is not a no-op; see above.

## Verification

- `pytest`: 188 passed.
- `pytest -m integration tests/integration` against `greptimedb:v1.2.0-beta.1` over stdio and streamable-http: 18 passed, including a new test asserting that argument validation failures reach the client with their reason.
- `--transport sse` started manually; `/sse` returns the endpoint event.
- Tool surface dumped from v1 and v2 on the same Python version and diffed: tool names, descriptions, input/output schemas, prompts and the resource template are identical. The only differences are Python-side field names (`inputSchema` → `input_schema`, unchanged on the wire) and the new `title` field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)