### PR TITLE
feat: expose entity declarations and add concept search over table semantics

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -60,8 +60,22 @@ jobs:
 
   # Uses `docker run` rather than `services:` because the image needs a
   # `standalone start ...` command, which `services:` cannot provide.
+  #
+  # Both versions are required. 1.3 exposes entity_declarations in the table
+  # semantics view; 1.2 does not, and covers the column-negotiation path that
+  # nothing else exercises. Digests are pinned so a retag cannot change what
+  # either job proves.
   integration:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - version: v1.2.0-beta.1
+            digest: sha256:adbc519ba58dc9542eef5243351d9e8381f87969e164f8630548e1fdae93c252
+          - version: v1.3.0-alpha.1
+            digest: sha256:d884e21552ec89f6d79247396334022b44f737b46601845e2d1de39699d79534
+    name: integration (${{ matrix.version }})
     steps:
     - uses: actions/checkout@v4
     - name: Install the latest version of uv
@@ -71,20 +85,23 @@ jobs:
       run: |
         docker run -d --name greptimedb \
           -p 127.0.0.1:4000:4000 -p 127.0.0.1:4002:4002 \
-          greptime/greptimedb:v1.2.0-beta.1 \
+          greptime/greptimedb@${{ matrix.digest }} \
           standalone start --http-addr 0.0.0.0:4000 --mysql-addr 0.0.0.0:4002
     - name: Wait for GreptimeDB
       run: |
-        # Grepping /status for the build info also proves we reached GreptimeDB
-        # and not some other service bound to the port.
+        # The two matrix legs assert different behaviour, so the reported
+        # version has to match the one this leg was meant to start.
+        expected="${{ matrix.version }}"
+        expected="${expected#v}"
         for _ in $(seq 1 60); do
-          if curl -sf http://127.0.0.1:4000/status | grep -q '"version"'; then
+          if curl -sf http://127.0.0.1:4000/status | grep -q "\"version\":\"$expected\""; then
             curl -s http://127.0.0.1:4000/status
             exit 0
           fi
           sleep 2
         done
-        echo "GreptimeDB did not become ready in time"
+        echo "GreptimeDB $expected did not become ready in time"
+        curl -s http://127.0.0.1:4000/status || true
         docker logs greptimedb
         exit 1
     - name: Install dependencies

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -94,7 +94,10 @@ jobs:
         expected="${{ matrix.version }}"
         expected="${expected#v}"
         for _ in $(seq 1 60); do
-          if curl -sf http://127.0.0.1:4000/status | grep -q "\"version\":\"$expected\""; then
+          # Parse rather than grep: a substring match on the JSON text breaks
+          # on whitespace the server is free to add.
+          if curl -sf http://127.0.0.1:4000/status \
+            | python3 -c "import json,sys; sys.exit(json.load(sys.stdin).get('version') != '$expected')"; then
             curl -s http://127.0.0.1:4000/status
             exit 0
           fi

--- a/README.md
+++ b/README.md
@@ -43,9 +43,12 @@ For Claude Desktop, add this to your config (`~/Library/Application Support/Clau
 | `execute_sql` | Execute SQL queries with format (csv/json/markdown) and limit options |
 | `execute_tql` | Execute TQL (PromQL-compatible) queries for time-series analysis |
 | `query_range` | Execute time-window aggregation queries with RANGE/ALIGN syntax |
+| `search_table_semantics` | Find tables by observability concept, ranked by matched terms; searches table names, semantic options, and entity declarations |
 | `describe_table` | Inspect a table profile: schema, semantic metadata, latest sample rows, and query guidance |
 | `explain_query` | Analyze SQL or TQL query execution plans (`analyze=true` for runtime stats; add `verbose=true` alongside `analyze=true` for per-partition scan metrics and index-pruning counters) |
 | `health_check` | Check database connection status and server version |
+
+`search_table_semantics` and the semantic metadata in `describe_table` read `information_schema.table_semantics`. A table appears there when it carries a `greptime.semantic.*` option or a built-in convention derives an entity declaration for it; other tables are absent. The server reads the view's column list once per process and selects only the columns it exposes. `entity_declarations` requires GreptimeDB 1.3; on earlier versions it is reported as a missing column rather than as an empty declaration set.
 
 ### Pipeline Management
 

--- a/conftest.py
+++ b/conftest.py
@@ -102,7 +102,6 @@ class MockCursor:
         elif self.query.upper().startswith(
             "DESC TABLE INFORMATION_SCHEMA.TABLE_SEMANTICS"
         ):
-            # Capability probe: one row per column of the semantics view.
             self._results = [(name,) for name in SEMANTICS_VIEW_COLUMNS]
         elif "INFORMATION_SCHEMA.TABLE_SEMANTICS" in self.query.upper():
             if "LIKE" in self.query.upper():

--- a/conftest.py
+++ b/conftest.py
@@ -1,6 +1,76 @@
 import pytest
 import sys
 
+# information_schema.table_semantics as GreptimeDB 1.3 exposes it. The server
+# probes this list and builds its SELECT from it, so tests that need an older
+# view drop columns from the probe rather than from the rows.
+SEMANTICS_VIEW_COLUMNS = (
+    "table_catalog",
+    "table_schema",
+    "table_name",
+    "table_id",
+    "signal_type",
+    "source",
+    "source_version",
+    "pipeline",
+    "metadata_quality",
+    "semantic_options",
+    "entity_declarations",
+)
+
+ENTITY_DECLARATIONS = (
+    '[{"entity_type":"service","id":["service_name"],'
+    '"id_qualifier":"service_namespace","origin":"convention"}]'
+)
+
+
+def semantics_row(table_schema, table_name):
+    """One row of the semantics view, in SEMANTICS_VIEW_COLUMNS order."""
+    return (
+        "greptime",
+        table_schema,
+        table_name,
+        1024,
+        "metric",
+        "opentelemetry",
+        "1.0",
+        "",
+        "declared",
+        '{"metric.type":"counter","metric.unit":"By"}',
+        ENTITY_DECLARATIONS,
+    )
+
+
+# Candidates the search returns; ranking, not the LIKE filter, decides order.
+SEMANTICS_SEARCH_ROWS = (
+    (
+        "greptime",
+        "testdb",
+        "redis_used_memory",
+        2048,
+        "metric",
+        "prometheus",
+        "2.0",
+        "",
+        "inferred",
+        '{"metric.type":"gauge","metric.unit":"By"}',
+        None,
+    ),
+    (
+        "greptime",
+        "testdb",
+        "http_request_duration",
+        2049,
+        "metric",
+        "opentelemetry",
+        "1.0",
+        "",
+        "declared",
+        '{"metric.type":"histogram"}',
+        None,
+    ),
+)
+
 
 # Mock classes for MySQL connection
 class MockCursor:
@@ -29,21 +99,16 @@ class MockCursor:
                 self._results = [("user activity table",)]
             else:
                 self._results = []
+        elif self.query.upper().startswith(
+            "DESC TABLE INFORMATION_SCHEMA.TABLE_SEMANTICS"
+        ):
+            # Capability probe: one row per column of the semantics view.
+            self._results = [(name,) for name in SEMANTICS_VIEW_COLUMNS]
         elif "INFORMATION_SCHEMA.TABLE_SEMANTICS" in self.query.upper():
-            if args and args[1] == "users":
-                self._results = [
-                    (
-                        "greptime",
-                        args[0],
-                        args[1],
-                        1024,
-                        "metric",
-                        "opentelemetry",
-                        "",
-                        "declared",
-                        '{"metric.type":"counter","metric.unit":"By"}',
-                    )
-                ]
+            if "LIKE" in self.query.upper():
+                self._results = list(SEMANTICS_SEARCH_ROWS)
+            elif args and args[1] == "users":
+                self._results = [semantics_row(args[0], args[1])]
             else:
                 self._results = []
         elif "DESCRIBE" in self.query.upper():
@@ -129,17 +194,7 @@ class MockCursor:
         elif "INFORMATION_SCHEMA.TABLES" in self.query.upper():
             return [("table_comment", None)]
         elif "INFORMATION_SCHEMA.TABLE_SEMANTICS" in self.query.upper():
-            return [
-                ("table_catalog", None),
-                ("table_schema", None),
-                ("table_name", None),
-                ("table_id", None),
-                ("signal_type", None),
-                ("source", None),
-                ("pipeline", None),
-                ("metadata_quality", None),
-                ("semantic_options", None),
-            ]
+            return [(name, None) for name in SEMANTICS_VIEW_COLUMNS]
         elif "VERSION()" in self.query.upper():
             return [("version()", None)]
         elif "TQL" in self.query.upper():

--- a/src/greptimedb_mcp_server/semantics.py
+++ b/src/greptimedb_mcp_server/semantics.py
@@ -1,10 +1,9 @@
-"""Reads GreptimeDB's table semantic metadata.
+"""Reads `information_schema.table_semantics`.
 
-Everything here is about one view, `information_schema.table_semantics`, whose
-shape varies by server version: `entity_declarations` arrived in GreptimeDB
-1.3, and selecting a column the view lacks fails the whole statement to plan.
-`SemanticsView` therefore negotiates the column list once and builds every
-query from what is actually exposed.
+The view's shape varies by server version -- `entity_declarations` arrived in
+GreptimeDB 1.3 -- and selecting a column it lacks fails the whole statement to
+plan, so `SemanticsView` negotiates the column list once and builds every query
+from what is actually exposed.
 """
 
 import json
@@ -17,7 +16,6 @@ from greptimedb_mcp_server.utils import escape_like_pattern
 
 VIEW = "information_schema.table_semantics"
 
-# Every column this server knows how to read, in SELECT order.
 COLUMNS = (
     "table_catalog",
     "table_schema",
@@ -32,7 +30,6 @@ COLUMNS = (
     "entity_declarations",
 )
 
-# Columns the searchable text is assembled from.
 SEARCH_COLUMNS = ("table_name", "semantic_options", "entity_declarations")
 
 VALID_SIGNAL_TYPES = ("metric", "log", "trace", "event")
@@ -114,13 +111,22 @@ class SearchRequest:
         )
 
 
+def _join_slash_abbreviations(value: str) -> str:
+    """Fold `I/O` into `io` so it survives tokenizing as one term.
+
+    Split on the slash it becomes `i` and `o`, which the one-character filter
+    then discards, and a search for `I/O` has nothing left to look for.
+    """
+    return re.sub(r"\b([A-Za-z])\s*/\s*([A-Za-z])\b", r"\1\2", value)
+
+
 def search_terms(query: str) -> list[str]:
     """Split a concept query into distinct searchable terms.
 
     Underscores become separators so that a query for `used memory` still
     matches `redis___used_memory_`.
     """
-    normalized = query.lower().replace("_", " ")
+    normalized = _join_slash_abbreviations(query).lower().replace("_", " ")
     terms = (
         term
         for term in re.findall(r"[a-z0-9.:-]+", normalized)
@@ -134,9 +140,20 @@ def matched_terms(terms: list[str], searchable: str) -> list[str]:
 
     Terms of one or two characters must match a whole token: a substring test
     would let `geo` match `range of`.
+
+    Legacy metric names abbreviate the I/O direction as a single letter, so
+    adjacent `io_w` and `io_r` are read back as `write` and `read`;
+    `unrelated_w_metric_io` is not a write metric. This and
+    `_join_slash_abbreviations` are ported from GreptimeTeam/agent-rca-bench,
+    where they are what made concept search work on legacy metric schemas.
     """
-    normalized = searchable.lower()
-    tokens = set(re.findall(r"[a-z0-9]+", normalized))
+    normalized = _join_slash_abbreviations(searchable).lower()
+    token_list = re.findall(r"[a-z0-9]+", normalized)
+    tokens = set(token_list)
+    adjacent = set(zip(token_list, token_list[1:]))
+    for direction, word in (("w", "write"), ("r", "read")):
+        if ("io", direction) in adjacent:
+            tokens.add(word)
     return [
         term
         for term in terms
@@ -292,13 +309,19 @@ def _build_search_sql(
         predicates.append("signal_type = %s")
         params.append(request.signal_type)
 
+    # Terms are ORed with each other: a table matching some of them is a
+    # candidate, and how many it matched is what ranking is for. ANDing them
+    # would drop `redis_used_memory` from a search for "redis memory usage"
+    # and leave every surviving row with an identical score.
+    term_clauses = []
     for term in request.terms:
         pattern = f"%{escape_like_pattern(term)}%"
         # COALESCE keeps a NULL column from making the whole OR group NULL,
         # which would drop rows that matched on another column.
         clauses = [f"LOWER(COALESCE({column}, '')) LIKE %s" for column in searchable]
-        predicates.append(f"({' OR '.join(clauses)})")
+        term_clauses.append(f"({' OR '.join(clauses)})")
         params.extend([pattern] * len(clauses))
+    predicates.append(f"({' OR '.join(term_clauses)})")
 
     sql = (
         f"SELECT {', '.join(columns)} FROM {VIEW} "

--- a/src/greptimedb_mcp_server/semantics.py
+++ b/src/greptimedb_mcp_server/semantics.py
@@ -12,8 +12,6 @@ from dataclasses import dataclass
 
 from mysql.connector import Error
 
-from greptimedb_mcp_server.utils import escape_like_pattern
-
 VIEW = "information_schema.table_semantics"
 
 COLUMNS = (
@@ -98,7 +96,7 @@ class SearchRequest:
                 f"Invalid signal_type: {signal_type}. "
                 f"Must be one of: {', '.join(VALID_SIGNAL_TYPES)}"
             )
-        terms = search_terms(query)
+        terms = _search_terms(query)
         if not terms:
             raise ValueError(
                 "query must contain at least one term of two or more characters"
@@ -120,11 +118,13 @@ def _join_slash_abbreviations(value: str) -> str:
     return re.sub(r"\b([A-Za-z])\s*/\s*([A-Za-z])\b", r"\1\2", value)
 
 
-def search_terms(query: str) -> list[str]:
+def _search_terms(query: str) -> list[str]:
     """Split a concept query into distinct searchable terms.
 
     Underscores become separators so that a query for `used memory` still
-    matches `redis___used_memory_`.
+    matches `redis___used_memory_`. The character class also keeps LIKE
+    metacharacters out of a term, which is what lets a term go into a LIKE
+    pattern as-is.
     """
     normalized = _join_slash_abbreviations(query).lower().replace("_", " ")
     terms = (
@@ -135,7 +135,7 @@ def search_terms(query: str) -> list[str]:
     return list(dict.fromkeys(terms))[:MAX_SEARCH_TERMS]
 
 
-def matched_terms(terms: list[str], searchable: str) -> list[str]:
+def _matched_terms(terms: list[str], searchable: str) -> list[str]:
     """Return the terms a candidate matched, for ranking.
 
     Terms of one or two characters must match a whole token: a substring test
@@ -315,7 +315,7 @@ def _build_search_sql(
     # and leave every surviving row with an identical score.
     term_clauses = []
     for term in request.terms:
-        pattern = f"%{escape_like_pattern(term)}%"
+        pattern = f"%{term}%"
         # COALESCE keeps a NULL column from making the whole OR group NULL,
         # which would drop rows that matched on another column.
         clauses = [f"LOWER(COALESCE({column}, '')) LIKE %s" for column in searchable]
@@ -350,7 +350,7 @@ def _candidate(values: dict, terms: list[str]) -> dict | None:
     searchable = " ".join(
         str(values.get(column)) for column in SEARCH_COLUMNS if values.get(column)
     )
-    matched = matched_terms(terms, searchable)
+    matched = _matched_terms(terms, searchable)
     if not matched:
         # The SQL LIKE matched a substring the ranking rules reject, such as a
         # short term inside a longer word.

--- a/src/greptimedb_mcp_server/semantics.py
+++ b/src/greptimedb_mcp_server/semantics.py
@@ -1,0 +1,498 @@
+"""Reads GreptimeDB's table semantic metadata.
+
+Everything here is about one view, `information_schema.table_semantics`, whose
+shape varies by server version: `entity_declarations` arrived in GreptimeDB
+1.3, and selecting a column the view lacks fails the whole statement to plan.
+`SemanticsView` therefore negotiates the column list once and builds every
+query from what is actually exposed.
+"""
+
+import json
+import re
+from dataclasses import dataclass
+
+from mysql.connector import Error
+
+from greptimedb_mcp_server.utils import escape_like_pattern
+
+VIEW = "information_schema.table_semantics"
+
+# Every column this server knows how to read, in SELECT order.
+COLUMNS = (
+    "table_catalog",
+    "table_schema",
+    "table_name",
+    "table_id",
+    "signal_type",
+    "source",
+    "source_version",
+    "pipeline",
+    "metadata_quality",
+    "semantic_options",
+    "entity_declarations",
+)
+
+# Columns the searchable text is assembled from.
+SEARCH_COLUMNS = ("table_name", "semantic_options", "entity_declarations")
+
+VALID_SIGNAL_TYPES = ("metric", "log", "trace", "event")
+
+MAX_SEARCH_LIMIT = 50
+MAX_SEARCH_TERMS = 10
+# Rows read before ranking. Ranking needs the whole candidate set, so this caps
+# the read rather than the reported matches.
+SEARCH_SCAN_LIMIT = 1000
+
+STOP_WORDS = frozenset(
+    {"and", "for", "from", "in", "of", "on", "or", "the", "to", "with"}
+)
+
+# Tells a missing view from a rejected one. Anything else stays uncached, so a
+# transient failure does not disable the feature for the life of the process.
+ERRNO_TABLE_NOT_FOUND = 1146
+ERRNO_PERMISSION_DENIED = frozenset({1044, 1045, 1142, 1143, 1227})
+
+
+@dataclass(frozen=True)
+class Capability:
+    """What the connected GreptimeDB exposes of the semantics view."""
+
+    status: str
+    columns: frozenset[str] = frozenset()
+    detail: str | None = None
+
+    @property
+    def available(self) -> bool:
+        return self.status == "available"
+
+    @property
+    def cacheable(self) -> bool:
+        """Whether the probe answered, as opposed to failing to run."""
+        return self.status in ("available", "unavailable", "permission_denied")
+
+    def selectable(self, columns) -> list[str]:
+        return [column for column in columns if column in self.columns]
+
+    def missing(self, columns) -> list[str]:
+        return [column for column in columns if column not in self.columns]
+
+
+@dataclass(frozen=True)
+class SearchRequest:
+    """A validated concept search."""
+
+    query: str
+    terms: list[str]
+    signal_type: str | None
+    limit: int
+
+    @classmethod
+    def parse(
+        cls, query: str, signal_type: str | None = None, limit: int = MAX_SEARCH_LIMIT
+    ) -> "SearchRequest":
+        """Validate tool arguments before a connection is taken from the pool.
+
+        Raises ValueError, which the tool boundary turns into a ToolError.
+        """
+        if not query or not query.strip():
+            raise ValueError("query is required")
+        if signal_type is not None and signal_type not in VALID_SIGNAL_TYPES:
+            raise ValueError(
+                f"Invalid signal_type: {signal_type}. "
+                f"Must be one of: {', '.join(VALID_SIGNAL_TYPES)}"
+            )
+        terms = search_terms(query)
+        if not terms:
+            raise ValueError(
+                "query must contain at least one term of two or more characters"
+            )
+        return cls(
+            query=query,
+            terms=terms,
+            signal_type=signal_type,
+            limit=max(1, min(limit, MAX_SEARCH_LIMIT)),
+        )
+
+
+def search_terms(query: str) -> list[str]:
+    """Split a concept query into distinct searchable terms.
+
+    Underscores become separators so that a query for `used memory` still
+    matches `redis___used_memory_`.
+    """
+    normalized = query.lower().replace("_", " ")
+    terms = (
+        term
+        for term in re.findall(r"[a-z0-9.:-]+", normalized)
+        if len(term) > 1 and term not in STOP_WORDS
+    )
+    return list(dict.fromkeys(terms))[:MAX_SEARCH_TERMS]
+
+
+def matched_terms(terms: list[str], searchable: str) -> list[str]:
+    """Return the terms a candidate matched, for ranking.
+
+    Terms of one or two characters must match a whole token: a substring test
+    would let `geo` match `range of`.
+    """
+    normalized = searchable.lower()
+    tokens = set(re.findall(r"[a-z0-9]+", normalized))
+    return [
+        term
+        for term in terms
+        if term in tokens or (len(term) > 2 and term in normalized)
+    ]
+
+
+def _parse_json_column(value, column: str, expected: type):
+    """Decode a semantics JSON column, keeping the raw text when it is not usable.
+
+    Returns (parsed, raw, error): callers surface raw/error instead of dropping
+    a payload whose shape this version does not expect.
+    """
+    if not value:
+        return None, None, None
+    try:
+        parsed = json.loads(value)
+    except (TypeError, json.JSONDecodeError) as e:
+        return None, value, str(e)
+    if not isinstance(parsed, expected):
+        shape = "object" if expected is dict else "array"
+        return None, value, f"{column} is not a JSON {shape}"
+    return parsed, None, None
+
+
+def guidance(profile: dict) -> list[str]:
+    """Query hints derived from a table's semantic profile."""
+    if not profile.get("included"):
+        return []
+
+    hints = _availability_guidance(profile)
+    hints.extend(_entity_declaration_guidance(profile))
+    hints.extend(_signal_guidance(profile))
+    return hints
+
+
+def _availability_guidance(profile: dict) -> list[str]:
+    if not profile.get("available", True):
+        if profile.get("reason") == "permission_denied":
+            return [
+                f"{VIEW} exists but this account cannot read it. Signal type "
+                "and query pattern below are schema/sample-based inference."
+            ]
+        return [
+            "Table semantic metadata is unavailable. The connected GreptimeDB "
+            f"version may not support {VIEW}."
+        ]
+    if not profile.get("found"):
+        return [
+            "No table semantic metadata was found. Treat signal type and "
+            "query pattern as schema/sample-based inference."
+        ]
+    return []
+
+
+def _entity_declaration_guidance(profile: dict) -> list[str]:
+    """Explain what the table contributes to the semantic graph, if anything."""
+    if not profile.get("found"):
+        return []
+
+    if "entity_declarations" in (profile.get("missing_columns") or []):
+        return [
+            "This GreptimeDB version does not expose entity_declarations, so "
+            "the entities this table contributes to the semantic graph cannot "
+            "be read here. Absence is a version limit, not evidence that the "
+            "table declares none."
+        ]
+
+    declarations = profile.get("entity_declarations")
+    if not declarations:
+        return [
+            "This table declares no semantic entities, so it contributes no "
+            "nodes to the semantic graph. Its rows are still queryable."
+        ]
+
+    types = sorted(
+        {
+            str(item.get("entity_type"))
+            for item in declarations
+            if isinstance(item, dict) and item.get("entity_type")
+        }
+    )
+    hints = []
+    if types:
+        hints.append(
+            f"This table contributes these semantic entities: {', '.join(types)}. "
+            "Each declaration's id lists the identifying columns, in order."
+        )
+    # The declared/convention split and a dropped id_qualifier are the only
+    # observable causes of one process appearing under two entity ids.
+    hints.append(
+        "Check origin and id_qualifier on each declaration before treating two "
+        "ids as two things. An explicit declaration replaces the built-in "
+        "convention for that entity type outright, so one that omits "
+        "id_qualifier silently drops the qualifier the convention would have "
+        "applied, and the same process can then appear under two ids."
+    )
+    return hints
+
+
+def _signal_guidance(profile: dict) -> list[str]:
+    signal_type = profile.get("signal_type")
+    options = profile.get("options") or {}
+    metric_type = options.get("metric.type")
+
+    if signal_type == "trace":
+        return [
+            "This table represents traces. Prefer latency, error span, and "
+            "service-level aggregation queries."
+        ]
+    if signal_type == "log":
+        return [
+            "This table represents logs. Prefer full-text search plus "
+            "severity, time, and service aggregations."
+        ]
+    if signal_type != "metric":
+        return []
+
+    hints = []
+    if metric_type == "counter":
+        hints.append(
+            "This table is a counter metric. Prefer rate or increase queries "
+            "for trend analysis."
+        )
+    elif metric_type == "gauge":
+        hints.append(
+            "This table is a gauge metric. Prefer absolute value, avg, min, "
+            "max, or percentile analysis."
+        )
+    elif metric_type == "histogram":
+        hints.append(
+            "This table is a histogram metric. Prefer bucket/count/sum based "
+            "percentile analysis."
+        )
+    if profile.get("metadata_quality") == "inferred":
+        hints.append(
+            "Metric type was inferred from naming. Re-check the query choice "
+            "if the metric name is non-standard."
+        )
+    return hints
+
+
+def _build_search_sql(
+    capability: Capability, request: SearchRequest, table_schema: str
+) -> tuple[str, list]:
+    """Build the candidate query and its bound parameters."""
+    columns = capability.selectable(COLUMNS)
+    searchable = capability.selectable(SEARCH_COLUMNS)
+
+    predicates = ["table_schema = %s"]
+    params: list = [table_schema]
+    if request.signal_type:
+        predicates.append("signal_type = %s")
+        params.append(request.signal_type)
+
+    for term in request.terms:
+        pattern = f"%{escape_like_pattern(term)}%"
+        # COALESCE keeps a NULL column from making the whole OR group NULL,
+        # which would drop rows that matched on another column.
+        clauses = [f"LOWER(COALESCE({column}, '')) LIKE %s" for column in searchable]
+        predicates.append(f"({' OR '.join(clauses)})")
+        params.extend([pattern] * len(clauses))
+
+    sql = (
+        f"SELECT {', '.join(columns)} FROM {VIEW} "
+        f"WHERE {' AND '.join(predicates)} "
+        f"ORDER BY table_name LIMIT {SEARCH_SCAN_LIMIT}"
+    )
+    return sql, params
+
+
+def _rank_candidates(columns: list[str], rows: list, terms: list[str]) -> list[dict]:
+    """Score rows by matched terms, dropping rows no term actually matched."""
+    candidates = []
+    for row in rows:
+        values = dict(zip(columns, row))
+        candidate = _candidate(values, terms)
+        if candidate is not None:
+            candidates.append(candidate)
+
+    candidates.sort(
+        key=lambda item: (-len(item["matched_terms"]), str(item["table"]).lower())
+    )
+    return candidates
+
+
+def _candidate(values: dict, terms: list[str]) -> dict | None:
+    searchable = " ".join(
+        str(values.get(column)) for column in SEARCH_COLUMNS if values.get(column)
+    )
+    matched = matched_terms(terms, searchable)
+    if not matched:
+        # The SQL LIKE matched a substring the ranking rules reject, such as a
+        # short term inside a longer word.
+        return None
+
+    candidate = {
+        "table": values.get("table_name"),
+        "signal_type": values.get("signal_type"),
+        "source": values.get("source"),
+        "source_version": values.get("source_version"),
+        "pipeline": values.get("pipeline"),
+        "metadata_quality": values.get("metadata_quality"),
+        "matched_terms": matched,
+    }
+    for column, expected, raw_key in (
+        ("semantic_options", dict, "raw_options"),
+        ("entity_declarations", list, "raw_entity_declarations"),
+    ):
+        parsed, raw, _ = _parse_json_column(values.get(column), column, expected)
+        if parsed is not None:
+            candidate[column] = parsed
+        elif raw is not None:
+            candidate[raw_key] = raw
+    return candidate
+
+
+@dataclass
+class SemanticsView:
+    """A handle on the semantics view that remembers what it exposes."""
+
+    capability: Capability | None = None
+
+    def negotiate(self, cursor) -> Capability:
+        """Probe the view once per process and reuse the answer.
+
+        Racing callers may both probe; the result is identical, so the extra
+        DESC is cheaper than serializing every read on a lock.
+        """
+        if self.capability is not None:
+            return self.capability
+        capability = _probe(cursor)
+        if capability.cacheable:
+            self.capability = capability
+        return capability
+
+    def fetch(self, cursor, table_schema: str, table_name: str) -> dict:
+        """Read one table's semantic profile, degrading if a column is absent."""
+        capability = self.negotiate(cursor)
+        if not capability.available:
+            return _unavailable(capability.status, capability.detail)
+
+        columns = capability.selectable(COLUMNS)
+        try:
+            cursor.execute(
+                f"SELECT {', '.join(columns)} FROM {VIEW} "
+                "WHERE table_schema = %s AND table_name = %s",
+                (table_schema, table_name),
+            )
+            # fetchall() drains the unbuffered cursor before the next query
+            # runs; the WHERE clause matches at most one row.
+            rows = cursor.fetchall()
+        except Error as e:
+            return _unavailable("error", str(e))
+
+        profile = {
+            "included": True,
+            "available": True,
+            "found": bool(rows),
+        }
+        missing = capability.missing(COLUMNS)
+        if missing:
+            profile["missing_columns"] = missing
+        if rows:
+            profile.update(_row_profile(dict(zip(columns, rows[0]))))
+        return profile
+
+    def search(self, cursor, table_schema: str, request: SearchRequest) -> dict:
+        """Rank tables in one schema by how many query terms they matched."""
+        capability = self.negotiate(cursor)
+        if not capability.available:
+            return {
+                "query": request.query,
+                "terms": request.terms,
+                "available": False,
+                "reason": capability.status,
+                "error": capability.detail,
+                "matches": [],
+            }
+
+        # Unlike fetch(), a failure here has nothing to degrade to, so the
+        # error propagates to the caller instead of becoming an empty result.
+        sql, params = _build_search_sql(capability, request, table_schema)
+        cursor.execute(sql, params)
+        columns = [desc[0] for desc in cursor.description]
+        rows = cursor.fetchall()
+        candidates = _rank_candidates(columns, rows, request.terms)
+
+        result = {
+            "query": request.query,
+            "terms": request.terms,
+            "available": True,
+            "signal_type": request.signal_type,
+            "searched_columns": capability.selectable(SEARCH_COLUMNS),
+            "matched_table_count": len(candidates),
+            "matches": candidates[: request.limit],
+            "truncated": len(rows) >= SEARCH_SCAN_LIMIT
+            or len(candidates) > request.limit,
+        }
+        unsearched = capability.missing(SEARCH_COLUMNS)
+        if unsearched:
+            result["unsearched_columns"] = unsearched
+        return result
+
+
+def _probe(cursor) -> Capability:
+    """Read the view's column set, classifying why it is unusable."""
+    try:
+        cursor.execute(f"DESC TABLE {VIEW}")
+        columns = frozenset(str(row[0]) for row in cursor.fetchall())
+    except Error as e:
+        errno = getattr(e, "errno", None)
+        if errno == ERRNO_TABLE_NOT_FOUND:
+            return Capability("unavailable", detail=str(e))
+        if errno in ERRNO_PERMISSION_DENIED:
+            return Capability("permission_denied", detail=str(e))
+        return Capability("error", detail=str(e))
+    return Capability("available", columns=columns)
+
+
+def _unavailable(reason: str, detail: str | None) -> dict:
+    return {
+        "included": True,
+        "available": False,
+        "found": False,
+        "reason": reason,
+        "error": detail,
+    }
+
+
+def _row_profile(values: dict) -> dict:
+    options, raw_options, options_error = _parse_json_column(
+        values.get("semantic_options"), "semantic_options", dict
+    )
+    declarations, raw_declarations, declarations_error = _parse_json_column(
+        values.get("entity_declarations"), "entity_declarations", list
+    )
+
+    profile = {
+        "table_catalog": values.get("table_catalog"),
+        "table_schema": values.get("table_schema"),
+        "table_name": values.get("table_name"),
+        "table_id": values.get("table_id"),
+        "signal_type": values.get("signal_type"),
+        "source": values.get("source"),
+        "source_version": values.get("source_version"),
+        "pipeline": values.get("pipeline"),
+        "metadata_quality": values.get("metadata_quality"),
+        "options": options or {},
+    }
+    if raw_options is not None:
+        profile["raw_options"] = raw_options
+        profile["options_parse_error"] = options_error
+    if declarations is not None:
+        profile["entity_declarations"] = declarations
+    if raw_declarations is not None:
+        profile["raw_entity_declarations"] = raw_declarations
+        profile["entity_declarations_parse_error"] = declarations_error
+    return profile

--- a/src/greptimedb_mcp_server/semantics.py
+++ b/src/greptimedb_mcp_server/semantics.py
@@ -139,7 +139,7 @@ def _matched_terms(terms: list[str], searchable: str) -> list[str]:
     """Return the terms a candidate matched, for ranking.
 
     Terms of one or two characters must match a whole token: a substring test
-    would let `geo` match `range of`.
+    would let `id` match `identity`.
 
     Legacy metric names abbreviate the I/O direction as a single letter, so
     adjacent `io_w` and `io_r` are read back as `write` and `read`;
@@ -197,6 +197,12 @@ def _availability_guidance(profile: dict) -> list[str]:
                 f"{VIEW} exists but this account cannot read it. Signal type "
                 "and query pattern below are schema/sample-based inference."
             ]
+        if profile.get("reason") == "error":
+            return [
+                f"Reading {VIEW} failed; the error field says why. This is a "
+                "failed read, not a statement about what this server supports, "
+                "and a retry may succeed."
+            ]
         return [
             "Table semantic metadata is unavailable. The connected GreptimeDB "
             f"version may not support {VIEW}."
@@ -242,15 +248,29 @@ def _entity_declaration_guidance(profile: dict) -> list[str]:
             f"This table contributes these semantic entities: {', '.join(types)}. "
             "Each declaration's id lists the identifying columns, in order."
         )
-    # The declared/convention split and a dropped id_qualifier are the only
-    # observable causes of one process appearing under two entity ids.
-    hints.append(
-        "Check origin and id_qualifier on each declaration before treating two "
-        "ids as two things. An explicit declaration replaces the built-in "
-        "convention for that entity type outright, so one that omits "
-        "id_qualifier silently drops the qualifier the convention would have "
-        "applied, and the same process can then appear under two ids."
+    # Only a hand-written declaration can drop the qualifier: it replaces the
+    # convention for that entity type outright, so one that omits id_qualifier
+    # loses the qualifier the convention would have applied. Naming the
+    # affected types keeps this off every other table's profile.
+    unqualified = sorted(
+        {
+            str(item.get("entity_type"))
+            for item in declarations
+            if isinstance(item, dict)
+            and item.get("origin") == "declared"
+            and not item.get("id_qualifier")
+            and item.get("entity_type")
+        }
     )
+    if unqualified:
+        hints.append(
+            f"These declarations are explicit and name no id_qualifier: "
+            f"{', '.join(unqualified)}. An explicit declaration replaces the "
+            "built-in convention for its entity type outright, so any "
+            "qualifier the convention would have applied is dropped, and one "
+            "process can then appear under two ids. Compare origin and "
+            "id_qualifier before treating two ids as two things."
+        )
     return hints
 
 
@@ -346,10 +366,37 @@ def _rank_candidates(columns: list[str], rows: list, terms: list[str]) -> list[d
     return candidates
 
 
+def _json_leaves(value) -> list[str]:
+    """Collect the leaf values of a decoded JSON payload."""
+    if isinstance(value, dict):
+        return [leaf for item in value.values() for leaf in _json_leaves(item)]
+    if isinstance(value, list):
+        return [leaf for item in value for leaf in _json_leaves(item)]
+    return [str(value)] if value not in (None, "") else []
+
+
+def _searchable_text(values: dict) -> str:
+    """Assemble the text a candidate is ranked on.
+
+    Only the values of the JSON columns take part. Their key names are the
+    schema's own vocabulary -- metric.type, origin, entity_type -- so ranking
+    on them gives a query like "metric type unit" a perfect score against every
+    metric table and collapses the ordering to table name.
+    """
+    parts = [str(values["table_name"])] if values.get("table_name") else []
+    for column in ("semantic_options", "entity_declarations"):
+        raw = values.get(column)
+        if not raw:
+            continue
+        try:
+            parts.extend(_json_leaves(json.loads(raw)))
+        except (TypeError, json.JSONDecodeError):
+            parts.append(str(raw))
+    return " ".join(parts)
+
+
 def _candidate(values: dict, terms: list[str]) -> dict | None:
-    searchable = " ".join(
-        str(values.get(column)) for column in SEARCH_COLUMNS if values.get(column)
-    )
+    searchable = _searchable_text(values)
     matched = _matched_terms(terms, searchable)
     if not matched:
         # The SQL LIKE matched a substring the ranking rules reject, such as a
@@ -448,6 +495,9 @@ class SemanticsView:
         rows = cursor.fetchall()
         candidates = _rank_candidates(columns, rows, request.terms)
 
+        # ORDER BY in the scan makes the truncation deterministic rather than
+        # arbitrary; the ranking below decides the order that is returned.
+        scan_truncated = len(rows) >= SEARCH_SCAN_LIMIT
         result = {
             "query": request.query,
             "terms": request.terms,
@@ -456,9 +506,15 @@ class SemanticsView:
             "searched_columns": capability.selectable(SEARCH_COLUMNS),
             "matched_table_count": len(candidates),
             "matches": candidates[: request.limit],
-            "truncated": len(rows) >= SEARCH_SCAN_LIMIT
-            or len(candidates) > request.limit,
+            "truncated": scan_truncated or len(candidates) > request.limit,
         }
+        if scan_truncated:
+            result["ranking_note"] = (
+                f"More than {SEARCH_SCAN_LIMIT} tables matched, so ranking saw "
+                "only the first that many by table name. These are not "
+                "necessarily the best matches; narrow the query or set "
+                "signal_type."
+            )
         unsearched = capability.missing(SEARCH_COLUMNS)
         if unsearched:
             result["unsearched_columns"] = unsearched

--- a/src/greptimedb_mcp_server/semantics.py
+++ b/src/greptimedb_mcp_server/semantics.py
@@ -440,7 +440,15 @@ def _json_leaves(value) -> list[str]:
     return [str(value)] if value not in (None, "") else []
 
 
-def _searchable_text(values: dict) -> str:
+# The JSON columns a candidate carries, with the shape each must have and the
+# key its text goes under when it does not have it.
+CANDIDATE_JSON_COLUMNS = (
+    ("semantic_options", dict, "raw_options"),
+    ("entity_declarations", list, "raw_entity_declarations"),
+)
+
+
+def _searchable_text(values: dict, decoded: dict) -> str:
     """Assemble the text a candidate is ranked on.
 
     Only the values of the JSON columns take part. Their key names are the
@@ -449,20 +457,22 @@ def _searchable_text(values: dict) -> str:
     metric table and collapses the ordering to table name.
     """
     parts = [str(values["table_name"])] if values.get("table_name") else []
-    for column in ("semantic_options", "entity_declarations"):
-        raw = values.get(column)
-        if not raw:
-            continue
-        try:
-            parts.extend(_json_leaves(json.loads(raw)))
-        except (TypeError, json.JSONDecodeError):
+    for parsed, raw in decoded.values():
+        if parsed is not None:
+            parts.extend(_json_leaves(parsed))
+        elif raw:
             parts.append(str(raw))
     return " ".join(parts)
 
 
 def _candidate(values: dict, terms: list[str]) -> dict | None:
-    searchable = _searchable_text(values)
-    matched = _matched_terms(terms, searchable)
+    # Decoded once and shared: ranking reads the values, the payload carries
+    # them, and an unusable column falls back to its raw text in one place.
+    decoded = {
+        column: _parse_json_column(values.get(column), column, expected)[:2]
+        for column, expected, _ in CANDIDATE_JSON_COLUMNS
+    }
+    matched = _matched_terms(terms, _searchable_text(values, decoded))
     if not matched:
         # The SQL LIKE matched a substring the ranking rules reject, such as a
         # short term inside a longer word.
@@ -477,11 +487,8 @@ def _candidate(values: dict, terms: list[str]) -> dict | None:
         "metadata_quality": values.get("metadata_quality"),
         "matched_terms": matched,
     }
-    for column, expected, raw_key in (
-        ("semantic_options", dict, "raw_options"),
-        ("entity_declarations", list, "raw_entity_declarations"),
-    ):
-        parsed, raw, _ = _parse_json_column(values.get(column), column, expected)
+    for column, _, raw_key in CANDIDATE_JSON_COLUMNS:
+        parsed, raw = decoded[column]
         if parsed is not None:
             candidate[column] = parsed
         elif raw is not None:

--- a/src/greptimedb_mcp_server/semantics.py
+++ b/src/greptimedb_mcp_server/semantics.py
@@ -369,40 +369,49 @@ def _build_search_sql(
 ) -> tuple[str, list]:
     """Build the candidate query and its bound parameters.
 
-    This LIKE filter is a deliberate over-approximation whose only job is to
-    bound what gets read; `_matched_terms` is the single definition of a match
-    and decides what is returned. Every pattern here is a superset of what that
-    rule accepts, so narrowing the read never hides a row the ranking wanted.
+    The LIKE filter is a deliberate over-approximation that only bounds what
+    gets read; `_matched_terms` decides what is returned. Every pattern here is
+    a superset of what that rule accepts, so narrowing never hides a row.
+
+    Ordering by hit count rather than by name is what makes the scan limit
+    safe: cut alphabetically, a table matching every term loses to one matching
+    a single term whose name sorts earlier and never reaches ranking. The name
+    is the tie-break, so the truncation stays deterministic.
     """
     columns = capability.selectable(COLUMNS)
     searchable = capability.selectable(SEARCH_COLUMNS)
 
+    # COALESCE keeps a NULL column from making a group NULL, which would drop
+    # rows that matched on another column.
+    groups = []
+    group_params: list = []
+    for term in request.terms:
+        patterns = _recall_patterns(term)
+        clauses = [
+            f"LOWER(COALESCE({column}, '')) LIKE %s"
+            for _ in patterns
+            for column in searchable
+        ]
+        groups.append(f"({' OR '.join(clauses)})")
+        group_params.extend(f"%{pattern}%" for pattern in patterns for _ in searchable)
+
+    # Terms are ORed: a table matching some of them is a candidate, and how
+    # many it matched is what ranking is for. ANDing them would drop
+    # `redis_used_memory` from a search for "redis memory usage".
+    hits = " + ".join(f"CASE WHEN {group} THEN 1 ELSE 0 END" for group in groups)
+
     predicates = ["table_schema = %s"]
-    params: list = [table_schema]
+    params: list = [*group_params, table_schema]
     if request.signal_type:
         predicates.append("signal_type = %s")
         params.append(request.signal_type)
-
-    # Terms are ORed with each other: a table matching some of them is a
-    # candidate, and how many it matched is what ranking is for. ANDing them
-    # would drop `redis_used_memory` from a search for "redis memory usage"
-    # and leave every surviving row with an identical score.
-    term_clauses = []
-    for term in request.terms:
-        for pattern in _recall_patterns(term):
-            # COALESCE keeps a NULL column from making the whole OR group NULL,
-            # which would drop rows that matched on another column.
-            clauses = [
-                f"LOWER(COALESCE({column}, '')) LIKE %s" for column in searchable
-            ]
-            term_clauses.append(f"({' OR '.join(clauses)})")
-            params.extend([f"%{pattern}%"] * len(clauses))
-    predicates.append(f"({' OR '.join(term_clauses)})")
+    predicates.append(f"({' OR '.join(groups)})")
+    params.extend(group_params)
 
     sql = (
-        f"SELECT {', '.join(columns)} FROM {VIEW} "
+        f"SELECT {', '.join(columns)}, {hits} AS term_hits FROM {VIEW} "
         f"WHERE {' AND '.join(predicates)} "
-        f"ORDER BY table_name LIMIT {SEARCH_SCAN_LIMIT}"
+        f"ORDER BY term_hits DESC, table_name LIMIT {SEARCH_SCAN_LIMIT}"
     )
     return sql, params
 
@@ -560,9 +569,9 @@ class SemanticsView:
         if scan_truncated:
             result["ranking_note"] = (
                 f"More than {SEARCH_SCAN_LIMIT} tables matched, so ranking saw "
-                "only the first that many by table name. These are not "
-                "necessarily the best matches; narrow the query or set "
-                "signal_type."
+                "the best that many by how many query terms each hit. Rows "
+                "below that cut were not considered; narrow the query or set "
+                "signal_type to be sure of the ordering."
             )
         unsearched = capability.missing(SEARCH_COLUMNS)
         if unsearched:

--- a/src/greptimedb_mcp_server/semantics.py
+++ b/src/greptimedb_mcp_server/semantics.py
@@ -109,28 +109,49 @@ class SearchRequest:
         )
 
 
-def _join_slash_abbreviations(value: str) -> str:
-    """Fold `I/O` into `io` so it survives tokenizing as one term.
+# Identifier tokens: an ALL-CAPS run, a word, or a number. Splitting on case
+# transitions as well as separators is what lets `usedMemoryBytes` and
+# `used_memory_bytes` tokenize alike, and keeps `nodeCPUSeconds` from becoming
+# one opaque token.
+_TOKEN = re.compile(r"[A-Z]+(?![a-z])|[A-Za-z][a-z0-9]*|[0-9]+")
+_SLASH_PAIR = re.compile(r"\b([A-Za-z])\s*/\s*([A-Za-z])\b")
 
-    Split on the slash it becomes `i` and `o`, which the one-character filter
-    then discards, and a search for `I/O` has nothing left to look for.
+# Legacy metric names abbreviate an I/O direction as a single letter beside the
+# subsystem, so `system_io_w_s` is a write metric. Each entry maps the word a
+# caller searches for to the adjacent token pair that stands for it. Ported
+# from GreptimeTeam/agent-rca-bench, where this is what made concept search
+# work on legacy metric schemas.
+TOKEN_SYNONYMS = {"write": ("io", "w"), "read": ("io", "r")}
+
+MIN_PREFIX_TERM = 3
+
+
+def _tokens(text: str) -> list[str]:
+    """Split an identifier or a query into comparable tokens.
+
+    A slash between two single letters is not a separator: `I/O` is one term,
+    and splitting it leaves two one-character tokens that the term filter then
+    discards, so a search for it would have nothing to look for.
     """
-    return re.sub(r"\b([A-Za-z])\s*/\s*([A-Za-z])\b", r"\1\2", value)
+    joined = _SLASH_PAIR.sub(r"\1\2", text)
+    return [token.lower() for token in _TOKEN.findall(joined)]
+
+
+def _expanded_tokens(text: str) -> set[str]:
+    """Tokens of `text`, plus the words its abbreviations stand for."""
+    tokens = _tokens(text)
+    expanded = set(tokens)
+    adjacent = set(zip(tokens, tokens[1:]))
+    for word, pair in TOKEN_SYNONYMS.items():
+        if pair in adjacent:
+            expanded.add(word)
+    return expanded
 
 
 def _search_terms(query: str) -> list[str]:
-    """Split a concept query into distinct searchable terms.
-
-    Underscores become separators so that a query for `used memory` still
-    matches `redis___used_memory_`. The character class also keeps LIKE
-    metacharacters out of a term, which is what lets a term go into a LIKE
-    pattern as-is.
-    """
-    normalized = _join_slash_abbreviations(query).lower().replace("_", " ")
+    """Split a concept query into distinct searchable terms."""
     terms = (
-        term
-        for term in re.findall(r"[a-z0-9.:-]+", normalized)
-        if len(term) > 1 and term not in STOP_WORDS
+        term for term in _tokens(query) if len(term) > 1 and term not in STOP_WORDS
     )
     return list(dict.fromkeys(terms))[:MAX_SEARCH_TERMS]
 
@@ -138,27 +159,36 @@ def _search_terms(query: str) -> list[str]:
 def _matched_terms(terms: list[str], searchable: str) -> list[str]:
     """Return the terms a candidate matched, for ranking.
 
-    Terms of one or two characters must match a whole token: a substring test
-    would let `id` match `identity`.
-
-    Legacy metric names abbreviate the I/O direction as a single letter, so
-    adjacent `io_w` and `io_r` are read back as `write` and `read`;
-    `unrelated_w_metric_io` is not a write metric. This and
-    `_join_slash_abbreviations` are ported from GreptimeTeam/agent-rca-bench,
-    where they are what made concept search work on legacy metric schemas.
+    One rule, applied per token: the term is the token, or -- from three
+    characters up -- a prefix of it. Matching per token rather than across the
+    whole string is what keeps `geo` out of `range of`, and a prefix rather
+    than a substring is what keeps it out of `rangeof` too.
     """
-    normalized = _join_slash_abbreviations(searchable).lower()
-    token_list = re.findall(r"[a-z0-9]+", normalized)
-    tokens = set(token_list)
-    adjacent = set(zip(token_list, token_list[1:]))
-    for direction, word in (("w", "write"), ("r", "read")):
-        if ("io", direction) in adjacent:
-            tokens.add(word)
+    tokens = _expanded_tokens(searchable)
     return [
         term
         for term in terms
-        if term in tokens or (len(term) > 2 and term in normalized)
+        if term in tokens
+        or (
+            len(term) >= MIN_PREFIX_TERM
+            and any(token.startswith(term) for token in tokens)
+        )
     ]
+
+
+def _recall_patterns(term: str) -> list[str]:
+    """LIKE patterns that must reach every row `_matched_terms` would accept.
+
+    A token or prefix match implies the term appears as a substring, so one
+    pattern covers it. A synonym does not: nothing in `system_io_w_s` contains
+    `write`, so searching for the abbreviation is what puts the row in front of
+    the matcher.
+    """
+    patterns = [term]
+    pair = TOKEN_SYNONYMS.get(term)
+    if pair:
+        patterns.append(pair[0])
+    return patterns
 
 
 def _parse_json_column(value, column: str, expected: type):
@@ -319,7 +349,13 @@ def _signal_guidance(profile: dict) -> list[str]:
 def _build_search_sql(
     capability: Capability, request: SearchRequest, table_schema: str
 ) -> tuple[str, list]:
-    """Build the candidate query and its bound parameters."""
+    """Build the candidate query and its bound parameters.
+
+    This LIKE filter is a deliberate over-approximation whose only job is to
+    bound what gets read; `_matched_terms` is the single definition of a match
+    and decides what is returned. Every pattern here is a superset of what that
+    rule accepts, so narrowing the read never hides a row the ranking wanted.
+    """
     columns = capability.selectable(COLUMNS)
     searchable = capability.selectable(SEARCH_COLUMNS)
 
@@ -335,12 +371,14 @@ def _build_search_sql(
     # and leave every surviving row with an identical score.
     term_clauses = []
     for term in request.terms:
-        pattern = f"%{term}%"
-        # COALESCE keeps a NULL column from making the whole OR group NULL,
-        # which would drop rows that matched on another column.
-        clauses = [f"LOWER(COALESCE({column}, '')) LIKE %s" for column in searchable]
-        term_clauses.append(f"({' OR '.join(clauses)})")
-        params.extend([pattern] * len(clauses))
+        for pattern in _recall_patterns(term):
+            # COALESCE keeps a NULL column from making the whole OR group NULL,
+            # which would drop rows that matched on another column.
+            clauses = [
+                f"LOWER(COALESCE({column}, '')) LIKE %s" for column in searchable
+            ]
+            term_clauses.append(f"({' OR '.join(clauses)})")
+            params.extend([f"%{pattern}%"] * len(clauses))
     predicates.append(f"({' OR '.join(term_clauses)})")
 
     sql = (

--- a/src/greptimedb_mcp_server/semantics.py
+++ b/src/greptimedb_mcp_server/semantics.py
@@ -191,6 +191,24 @@ def _recall_patterns(term: str) -> list[str]:
     return patterns
 
 
+def search_failure(request: SearchRequest, reason: str, detail: str | None) -> dict:
+    """The envelope every unsuccessful search returns.
+
+    Success and failure share query, terms, signal_type, available,
+    matched_table_count and matches, so one shape parses either.
+    """
+    return {
+        "query": request.query,
+        "terms": request.terms,
+        "signal_type": request.signal_type,
+        "available": False,
+        "reason": reason,
+        "error": detail,
+        "matched_table_count": 0,
+        "matches": [],
+    }
+
+
 def _parse_json_column(value, column: str, expected: type):
     """Decode a semantics JSON column, keeping the raw text when it is not usable.
 
@@ -516,14 +534,7 @@ class SemanticsView:
         """Rank tables in one schema by how many query terms they matched."""
         capability = self.negotiate(cursor)
         if not capability.available:
-            return {
-                "query": request.query,
-                "terms": request.terms,
-                "available": False,
-                "reason": capability.status,
-                "error": capability.detail,
-                "matches": [],
-            }
+            return search_failure(request, capability.status, capability.detail)
 
         # Unlike fetch(), a failure here has nothing to degrade to, so the
         # error propagates to the caller instead of becoming an empty result.

--- a/src/greptimedb_mcp_server/server.py
+++ b/src/greptimedb_mcp_server/server.py
@@ -44,7 +44,6 @@ from mysql.connector import connect, Error
 from mysql.connector.pooling import MySQLConnectionPool
 
 # Constants
-RES_PREFIX = "greptime://"
 RESULTS_LIMIT = 100
 MAX_QUERY_LIMIT = 10000
 MAX_SAMPLE_LIMIT = 20

--- a/src/greptimedb_mcp_server/server.py
+++ b/src/greptimedb_mcp_server/server.py
@@ -47,12 +47,73 @@ RES_PREFIX = "greptime://"
 RESULTS_LIMIT = 100
 MAX_QUERY_LIMIT = 10000
 MAX_SAMPLE_LIMIT = 20
+MAX_SEARCH_LIMIT = 50
+# Rows read from the semantics view before ranking. Ranking needs the whole
+# candidate set, so this caps the read rather than the reported matches.
+SEARCH_SCAN_LIMIT = 1000
+MAX_SEARCH_TERMS = 10
+
+SEMANTICS_VIEW = "information_schema.table_semantics"
+SEMANTICS_COLUMNS = (
+    "table_catalog",
+    "table_schema",
+    "table_name",
+    "table_id",
+    "signal_type",
+    "source",
+    "source_version",
+    "pipeline",
+    "metadata_quality",
+    "semantic_options",
+    "entity_declarations",
+)
+# Columns the searchable text is assembled from, in match priority order.
+SEARCH_COLUMNS = ("table_name", "semantic_options", "entity_declarations")
+SEARCH_STOP_WORDS = frozenset(
+    {"and", "for", "from", "in", "of", "on", "or", "the", "to", "with"}
+)
+VALID_SIGNAL_TYPES = ("metric", "log", "trace", "event")
+
+# MySQL error numbers used to tell a missing view from a rejected one. Anything
+# else stays uncached, so a transient failure does not disable the feature for
+# the life of the process.
+ERRNO_TABLE_NOT_FOUND = 1146
+ERRNO_PERMISSION_DENIED = frozenset({1044, 1045, 1142, 1143, 1227})
 
 # Configure logging
 logging.basicConfig(
     level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
 )
 logger = logging.getLogger("greptimedb_mcp_server")
+
+
+@dataclass(frozen=True)
+class SemanticsCapability:
+    """What the connected GreptimeDB exposes of the table semantics view.
+
+    `columns` drives the SELECT list: a column absent from the view makes the
+    whole statement fail to plan, so the query is built from what is actually
+    there rather than from what this version of the server knows about.
+    """
+
+    status: str
+    columns: frozenset[str] = frozenset()
+    detail: str | None = None
+
+    @property
+    def available(self) -> bool:
+        return self.status == "available"
+
+    @property
+    def cacheable(self) -> bool:
+        """Whether the probe answered, as opposed to failing to run."""
+        return self.status in ("available", "unavailable", "permission_denied")
+
+    def has(self, column: str) -> bool:
+        return column in self.columns
+
+    def selectable(self, columns) -> list[str]:
+        return [column for column in columns if column in self.columns]
 
 
 @dataclass
@@ -68,6 +129,7 @@ class AppState:
     allow_write: bool = False
     pool: MySQLConnectionPool | None = field(default=None)
     http_session: aiohttp.ClientSession | None = field(default=None)
+    semantics_capability: SemanticsCapability | None = field(default=None)
 
     def get_connection(self):
         """Get a connection from the pool, creating pool if needed."""
@@ -218,17 +280,74 @@ def _fetch_table_comment(cursor, table_schema: str, table_name: str) -> str | No
     return None
 
 
-def _fetch_table_semantics(cursor, table_schema: str, table_name: str) -> dict:
-    """Read the experimental table_semantics view, degrading if it is absent."""
+def _probe_table_semantics(cursor) -> SemanticsCapability:
+    """Read the semantics view's column set, classifying why it is unusable."""
+    try:
+        cursor.execute(f"DESC TABLE {SEMANTICS_VIEW}")
+        columns = frozenset(str(row[0]) for row in cursor.fetchall())
+    except Error as e:
+        errno = getattr(e, "errno", None)
+        if errno == ERRNO_TABLE_NOT_FOUND:
+            return SemanticsCapability("unavailable", detail=str(e))
+        if errno in ERRNO_PERMISSION_DENIED:
+            return SemanticsCapability("permission_denied", detail=str(e))
+        return SemanticsCapability("error", detail=str(e))
+    return SemanticsCapability("available", columns=columns)
+
+
+def _table_semantics_capability(state: AppState, cursor) -> SemanticsCapability:
+    """Probe the semantics view once per process and reuse the answer.
+
+    Racing callers may both probe; the result is identical, so the extra DESC
+    is cheaper than serializing every describe_table on a lock.
+    """
+    cached = state.semantics_capability
+    if cached is not None:
+        return cached
+    capability = _probe_table_semantics(cursor)
+    if capability.cacheable:
+        state.semantics_capability = capability
+    return capability
+
+
+def _parse_semantic_json(value, column: str, expected: type):
+    """Decode a semantics JSON column, keeping the raw text when it is not usable.
+
+    Returns (parsed, raw, error): callers surface raw/error instead of dropping
+    a payload whose shape this version does not expect.
+    """
+    if not value:
+        return None, None, None
+    try:
+        parsed = json.loads(value)
+    except (TypeError, json.JSONDecodeError) as e:
+        return None, value, str(e)
+    if not isinstance(parsed, expected):
+        shape = "object" if expected is dict else "array"
+        return None, value, f"{column} is not a JSON {shape}"
+    return parsed, None, None
+
+
+def _fetch_table_semantics(
+    state: AppState, cursor, table_schema: str, table_name: str
+) -> dict:
+    """Read the table_semantics view, degrading if it or a column is absent."""
+    capability = _table_semantics_capability(state, cursor)
+    if not capability.available:
+        return {
+            "included": True,
+            "available": False,
+            "found": False,
+            "reason": capability.status,
+            "error": capability.detail,
+        }
+
+    columns = capability.selectable(SEMANTICS_COLUMNS)
+    missing = [c for c in SEMANTICS_COLUMNS if c not in capability.columns]
     try:
         cursor.execute(
-            """
-            SELECT table_catalog, table_schema, table_name, table_id,
-                   signal_type, source, pipeline, metadata_quality,
-                   semantic_options
-            FROM information_schema.table_semantics
-            WHERE table_schema = %s AND table_name = %s
-            """,
+            f"SELECT {', '.join(columns)} FROM {SEMANTICS_VIEW} "
+            "WHERE table_schema = %s AND table_name = %s",
             (table_schema, table_name),
         )
         # fetchall() drains the unbuffered cursor before the next query runs;
@@ -240,48 +359,46 @@ def _fetch_table_semantics(cursor, table_schema: str, table_name: str) -> dict:
             "included": True,
             "available": False,
             "found": False,
+            "reason": "error",
             "error": str(e),
         }
 
-    if not row:
-        return {"included": True, "available": True, "found": False}
+    result = {"included": True, "available": True, "found": row is not None}
+    if missing:
+        result["missing_columns"] = missing
+    if row is None:
+        return result
 
-    semantic_options = row[8]
-    options = {}
-    raw_options = None
-    parse_error = None
-    if semantic_options:
-        try:
-            parsed = json.loads(semantic_options)
-        except (TypeError, json.JSONDecodeError) as e:
-            raw_options = semantic_options
-            parse_error = str(e)
-        else:
-            # Guidance treats options as a key/value map; a non-object payload
-            # would crash _build_table_guidance, so keep it as raw instead.
-            if isinstance(parsed, dict):
-                options = parsed
-            else:
-                raw_options = semantic_options
-                parse_error = "semantic_options is not a JSON object"
+    values = dict(zip(columns, row))
+    options, raw_options, options_error = _parse_semantic_json(
+        values.get("semantic_options"), "semantic_options", dict
+    )
+    declarations, raw_declarations, declarations_error = _parse_semantic_json(
+        values.get("entity_declarations"), "entity_declarations", list
+    )
 
-    result = {
-        "included": True,
-        "available": True,
-        "found": True,
-        "table_catalog": row[0],
-        "table_schema": row[1],
-        "table_name": row[2],
-        "table_id": row[3],
-        "signal_type": row[4],
-        "source": row[5],
-        "pipeline": row[6],
-        "metadata_quality": row[7],
-        "options": options,
-    }
+    result.update(
+        {
+            "table_catalog": values.get("table_catalog"),
+            "table_schema": values.get("table_schema"),
+            "table_name": values.get("table_name"),
+            "table_id": values.get("table_id"),
+            "signal_type": values.get("signal_type"),
+            "source": values.get("source"),
+            "source_version": values.get("source_version"),
+            "pipeline": values.get("pipeline"),
+            "metadata_quality": values.get("metadata_quality"),
+            "options": options or {},
+        }
+    )
     if raw_options is not None:
         result["raw_options"] = raw_options
-        result["options_parse_error"] = parse_error
+        result["options_parse_error"] = options_error
+    if declarations is not None:
+        result["entity_declarations"] = declarations
+    if raw_declarations is not None:
+        result["raw_entity_declarations"] = raw_declarations
+        result["entity_declarations_parse_error"] = declarations_error
     return result
 
 
@@ -338,19 +455,114 @@ def _fetch_table_samples(
         }
 
 
+def _search_terms(query: str) -> list[str]:
+    """Split a concept query into distinct searchable terms.
+
+    Underscores become separators so that a query for `used memory` still
+    matches `redis___used_memory_`.
+    """
+    normalized = query.lower().replace("_", " ")
+    terms = (
+        term
+        for term in re.findall(r"[a-z0-9.:-]+", normalized)
+        if len(term) > 1 and term not in SEARCH_STOP_WORDS
+    )
+    return list(dict.fromkeys(terms))[:MAX_SEARCH_TERMS]
+
+
+def _escape_like(term: str) -> str:
+    """Neutralize LIKE wildcards in a user-supplied term.
+
+    GreptimeDB rejects the ESCAPE clause but treats a backslash as the escape
+    character, so the term is escaped for the default and bound as a parameter.
+    """
+    for char in ("\\", "%", "_"):
+        term = term.replace(char, "\\" + char)
+    return term
+
+
+def _matched_terms(terms: list[str], searchable: str) -> list[str]:
+    """Return the terms a candidate matched, for ranking.
+
+    Terms of one or two characters must match a whole token: a substring test
+    would let `geo` match `range of`.
+    """
+    normalized = searchable.lower()
+    tokens = set(re.findall(r"[a-z0-9]+", normalized))
+    return [
+        term
+        for term in terms
+        if term in tokens or (len(term) > 2 and term in normalized)
+    ]
+
+
+def _entity_declaration_guidance(semantics: dict) -> list[str]:
+    """Explain what the table contributes to the semantic graph, if anything."""
+    if not semantics.get("included") or not semantics.get("found"):
+        return []
+
+    if "entity_declarations" in (semantics.get("missing_columns") or []):
+        return [
+            "This GreptimeDB version does not expose entity_declarations, so "
+            "the entities this table contributes to the semantic graph cannot "
+            "be read here. Absence is a version limit, not evidence that the "
+            "table declares none."
+        ]
+
+    declarations = semantics.get("entity_declarations")
+    if not declarations:
+        return [
+            "This table declares no semantic entities, so it contributes no "
+            "nodes to the semantic graph. Its rows are still queryable."
+        ]
+
+    types = sorted(
+        {
+            str(item.get("entity_type"))
+            for item in declarations
+            if isinstance(item, dict) and item.get("entity_type")
+        }
+    )
+    guidance = []
+    if types:
+        guidance.append(
+            f"This table contributes these semantic entities: {', '.join(types)}. "
+            "Each declaration's id lists the identifying columns, in order."
+        )
+    # The declared/convention split and a dropped id_qualifier are the only
+    # observable causes of one process appearing under two entity ids.
+    guidance.append(
+        "Check origin and id_qualifier on each declaration before treating two "
+        "ids as two things. An explicit declaration replaces the built-in "
+        "convention for that entity type outright, so one that omits "
+        "id_qualifier silently drops the qualifier the convention would have "
+        "applied, and the same process can then appear under two ids."
+    )
+    return guidance
+
+
 def _build_table_guidance(schema: dict, semantics: dict, samples: dict) -> list[str]:
     """Derive query hints from signal type, metric kind, and sample ordering."""
     guidance = []
     if semantics.get("included") and not semantics.get("available", True):
-        guidance.append(
-            "Table semantic metadata is unavailable. The connected GreptimeDB "
-            "version may not support information_schema.table_semantics."
-        )
+        if semantics.get("reason") == "permission_denied":
+            guidance.append(
+                f"{SEMANTICS_VIEW} exists but this account cannot read it. "
+                "Signal type and query pattern below are schema/sample-based "
+                "inference."
+            )
+        else:
+            guidance.append(
+                "Table semantic metadata is unavailable. The connected "
+                f"GreptimeDB version may not support {SEMANTICS_VIEW}."
+            )
     elif semantics.get("included") and not semantics.get("found"):
         guidance.append(
             "No table semantic metadata was found. Treat signal type and "
             "query pattern as schema/sample-based inference."
         )
+
+    guidance.extend(_entity_declaration_guidance(semantics))
 
     signal_type = semantics.get("signal_type")
     options = semantics.get("options") or {}
@@ -653,7 +865,22 @@ async def describe_table(
         f"Maximum sample rows to return (0-{MAX_SAMPLE_LIMIT}, default: 5)",
     ] = 5,
 ) -> str:
-    """Get a table profile: schema, semantic metadata, sample rows, and guidance."""
+    """Get a table profile: schema, semantic metadata, sample rows, and guidance.
+
+    Use it when deciding how to query an unfamiliar table. When the right table
+    is not known yet, search_table_semantics first; describing candidates one
+    by one is slower than querying the data.
+
+    The semantic profile says what the table means, not what its data says.
+    signal_type is metric, log, trace, or event; source and source_version name
+    the ingestion protocol; pipeline names the schema that shaped the rows;
+    semantic_options carries signal-specific facts such as metric type and
+    unit. metadata_quality describes how the metric type was obtained --
+    `declared` by the protocol or `inferred` from the name -- and says nothing
+    about telemetry quality. entity_declarations lists the entities the table
+    contributes to the semantic graph. A null or missing semantic field means
+    unknown, not the opposite fact.
+    """
     state = get_state()
     table = validate_table_name(table)
     sample_limit = max(0, min(sample_limit, MAX_SAMPLE_LIMIT))
@@ -683,7 +910,7 @@ async def describe_table(
                     )
                 table_comment = _fetch_table_comment(cursor, table_schema, table_name)
                 semantics = (
-                    _fetch_table_semantics(cursor, table_schema, table_name)
+                    _fetch_table_semantics(state, cursor, table_schema, table_name)
                     if include_semantics
                     else {"included": False}
                 )
@@ -721,6 +948,181 @@ async def describe_table(
             indent=2,
             default=str,
         )
+
+
+def _search_table_semantics_sql(
+    capability: SemanticsCapability,
+    terms: list[str],
+    table_schema: str,
+    signal_type: str | None,
+) -> tuple[str, list]:
+    """Build the candidate query and its bound parameters."""
+    columns = capability.selectable(SEMANTICS_COLUMNS)
+    searchable = capability.selectable(SEARCH_COLUMNS)
+
+    predicates = ["table_schema = %s"]
+    params: list = [table_schema]
+    if signal_type:
+        predicates.append("signal_type = %s")
+        params.append(signal_type)
+
+    for term in terms:
+        pattern = f"%{_escape_like(term)}%"
+        # COALESCE keeps a NULL column from making the whole OR group NULL,
+        # which would drop rows that matched on another column.
+        clauses = [f"LOWER(COALESCE({column}, '')) LIKE %s" for column in searchable]
+        predicates.append(f"({' OR '.join(clauses)})")
+        params.extend([pattern] * len(clauses))
+
+    sql = (
+        f"SELECT {', '.join(columns)} FROM {SEMANTICS_VIEW} "
+        f"WHERE {' AND '.join(predicates)} "
+        f"ORDER BY table_name LIMIT {SEARCH_SCAN_LIMIT}"
+    )
+    return sql, params
+
+
+def _rank_search_candidates(
+    columns: list[str], rows: list, terms: list[str]
+) -> list[dict]:
+    """Score rows by matched terms, dropping rows no term actually matched."""
+    candidates = []
+    for row in rows:
+        values = dict(zip(columns, row))
+        options, raw_options, _ = _parse_semantic_json(
+            values.get("semantic_options"), "semantic_options", dict
+        )
+        declarations, raw_declarations, _ = _parse_semantic_json(
+            values.get("entity_declarations"), "entity_declarations", list
+        )
+        searchable = " ".join(
+            str(part)
+            for part in (
+                values.get("table_name"),
+                values.get("semantic_options"),
+                values.get("entity_declarations"),
+            )
+            if part
+        )
+        matched = _matched_terms(terms, searchable)
+        if not matched:
+            # The SQL LIKE matched a substring the ranking rules reject, such
+            # as a short term inside a longer word.
+            continue
+        candidate = {
+            "table": values.get("table_name"),
+            "signal_type": values.get("signal_type"),
+            "source": values.get("source"),
+            "source_version": values.get("source_version"),
+            "pipeline": values.get("pipeline"),
+            "metadata_quality": values.get("metadata_quality"),
+            "matched_terms": matched,
+        }
+        if options:
+            candidate["semantic_options"] = options
+        elif raw_options:
+            candidate["semantic_options"] = raw_options
+        if declarations:
+            candidate["entity_declarations"] = declarations
+        elif raw_declarations:
+            candidate["entity_declarations"] = raw_declarations
+        candidates.append(candidate)
+
+    candidates.sort(
+        key=lambda item: (-len(item["matched_terms"]), str(item["table"]).lower())
+    )
+    return candidates
+
+
+@tool()
+async def search_table_semantics(
+    query: Annotated[
+        str,
+        "Telemetry concepts to search for, such as 'redis memory usage' or "
+        "'request latency'",
+    ],
+    signal_type: Annotated[
+        str | None,
+        f"Restrict results to one signal type: {', '.join(VALID_SIGNAL_TYPES)}",
+    ] = None,
+    limit: Annotated[
+        int, f"Maximum tables to return (1-{MAX_SEARCH_LIMIT}, default: 50)"
+    ] = MAX_SEARCH_LIMIT,
+) -> str:
+    """Find tables by observability concept when the right table name is unknown.
+
+    Searches table names, semantic options, and entity declarations, and ranks
+    tables by how many query terms they matched. Use it before describe_table
+    when the schema is wide or table names do not say what they hold.
+
+    It searches schema metadata only, never telemetry row values, so it can say
+    which table holds Redis memory usage but not which row belongs to
+    `Redis02`. Once it returns candidates, query their data or describe one of
+    them; do not describe every candidate in turn.
+
+    Only tables carrying a `greptime.semantic.*` option, or one a built-in
+    convention derives a declaration for, are visible here. A table absent from
+    the results may still exist and hold the data, so fall back to SHOW TABLES
+    rather than concluding it is not there.
+    """
+    state = get_state()
+    if not query or not query.strip():
+        raise ValueError("query is required")
+    if signal_type is not None and signal_type not in VALID_SIGNAL_TYPES:
+        raise ValueError(
+            f"Invalid signal_type: {signal_type}. "
+            f"Must be one of: {', '.join(VALID_SIGNAL_TYPES)}"
+        )
+    terms = _search_terms(query)
+    if not terms:
+        raise ValueError(
+            "query must contain at least one term of two or more characters"
+        )
+    limit = max(1, min(limit, MAX_SEARCH_LIMIT))
+    table_schema = state.db_config["database"]
+
+    def _sync_search():
+        with state.get_connection() as conn:
+            with conn.cursor() as cursor:
+                capability = _table_semantics_capability(state, cursor)
+                if not capability.available:
+                    return {
+                        "query": query,
+                        "terms": terms,
+                        "available": False,
+                        "reason": capability.status,
+                        "error": capability.detail,
+                        "matches": [],
+                    }
+                sql, params = _search_table_semantics_sql(
+                    capability, terms, table_schema, signal_type
+                )
+                cursor.execute(sql, params)
+                columns = [desc[0] for desc in cursor.description]
+                rows = cursor.fetchall()
+                candidates = _rank_search_candidates(columns, rows, terms)
+                result = {
+                    "query": query,
+                    "terms": terms,
+                    "available": True,
+                    "signal_type": signal_type,
+                    "searched_columns": capability.selectable(SEARCH_COLUMNS),
+                    "matched_table_count": len(candidates),
+                    "matches": candidates[:limit],
+                    "truncated": len(rows) >= SEARCH_SCAN_LIMIT
+                    or len(candidates) > limit,
+                }
+                missing = [c for c in SEARCH_COLUMNS if not capability.has(c)]
+                if missing:
+                    result["unsearched_columns"] = missing
+                return result
+
+    try:
+        result = await asyncio.to_thread(_sync_search)
+    except Error as e:
+        logger.error(f"Error searching table semantics for '{query}': {e}")
+        return f"Error searching table semantics: {str(e)}"
+    return json.dumps(result, ensure_ascii=False, indent=2, default=str)
 
 
 @tool()

--- a/src/greptimedb_mcp_server/server.py
+++ b/src/greptimedb_mcp_server/server.py
@@ -8,6 +8,7 @@ import sys
 if sys.platform == "win32" and any(t in sys.argv for t in ("sse", "streamable-http")):
     asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
 
+from greptimedb_mcp_server import semantics
 from greptimedb_mcp_server.config import Config
 from greptimedb_mcp_server.formatter import format_results, VALID_FORMATS
 from greptimedb_mcp_server.utils import (
@@ -47,73 +48,11 @@ RES_PREFIX = "greptime://"
 RESULTS_LIMIT = 100
 MAX_QUERY_LIMIT = 10000
 MAX_SAMPLE_LIMIT = 20
-MAX_SEARCH_LIMIT = 50
-# Rows read from the semantics view before ranking. Ranking needs the whole
-# candidate set, so this caps the read rather than the reported matches.
-SEARCH_SCAN_LIMIT = 1000
-MAX_SEARCH_TERMS = 10
-
-SEMANTICS_VIEW = "information_schema.table_semantics"
-SEMANTICS_COLUMNS = (
-    "table_catalog",
-    "table_schema",
-    "table_name",
-    "table_id",
-    "signal_type",
-    "source",
-    "source_version",
-    "pipeline",
-    "metadata_quality",
-    "semantic_options",
-    "entity_declarations",
-)
-# Columns the searchable text is assembled from, in match priority order.
-SEARCH_COLUMNS = ("table_name", "semantic_options", "entity_declarations")
-SEARCH_STOP_WORDS = frozenset(
-    {"and", "for", "from", "in", "of", "on", "or", "the", "to", "with"}
-)
-VALID_SIGNAL_TYPES = ("metric", "log", "trace", "event")
-
-# MySQL error numbers used to tell a missing view from a rejected one. Anything
-# else stays uncached, so a transient failure does not disable the feature for
-# the life of the process.
-ERRNO_TABLE_NOT_FOUND = 1146
-ERRNO_PERMISSION_DENIED = frozenset({1044, 1045, 1142, 1143, 1227})
-
 # Configure logging
 logging.basicConfig(
     level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
 )
 logger = logging.getLogger("greptimedb_mcp_server")
-
-
-@dataclass(frozen=True)
-class SemanticsCapability:
-    """What the connected GreptimeDB exposes of the table semantics view.
-
-    `columns` drives the SELECT list: a column absent from the view makes the
-    whole statement fail to plan, so the query is built from what is actually
-    there rather than from what this version of the server knows about.
-    """
-
-    status: str
-    columns: frozenset[str] = frozenset()
-    detail: str | None = None
-
-    @property
-    def available(self) -> bool:
-        return self.status == "available"
-
-    @property
-    def cacheable(self) -> bool:
-        """Whether the probe answered, as opposed to failing to run."""
-        return self.status in ("available", "unavailable", "permission_denied")
-
-    def has(self, column: str) -> bool:
-        return column in self.columns
-
-    def selectable(self, columns) -> list[str]:
-        return [column for column in columns if column in self.columns]
 
 
 @dataclass
@@ -129,7 +68,9 @@ class AppState:
     allow_write: bool = False
     pool: MySQLConnectionPool | None = field(default=None)
     http_session: aiohttp.ClientSession | None = field(default=None)
-    semantics_capability: SemanticsCapability | None = field(default=None)
+    table_semantics: semantics.SemanticsView = field(
+        default_factory=semantics.SemanticsView
+    )
 
     def get_connection(self):
         """Get a connection from the pool, creating pool if needed."""
@@ -280,128 +221,6 @@ def _fetch_table_comment(cursor, table_schema: str, table_name: str) -> str | No
     return None
 
 
-def _probe_table_semantics(cursor) -> SemanticsCapability:
-    """Read the semantics view's column set, classifying why it is unusable."""
-    try:
-        cursor.execute(f"DESC TABLE {SEMANTICS_VIEW}")
-        columns = frozenset(str(row[0]) for row in cursor.fetchall())
-    except Error as e:
-        errno = getattr(e, "errno", None)
-        if errno == ERRNO_TABLE_NOT_FOUND:
-            return SemanticsCapability("unavailable", detail=str(e))
-        if errno in ERRNO_PERMISSION_DENIED:
-            return SemanticsCapability("permission_denied", detail=str(e))
-        return SemanticsCapability("error", detail=str(e))
-    return SemanticsCapability("available", columns=columns)
-
-
-def _table_semantics_capability(state: AppState, cursor) -> SemanticsCapability:
-    """Probe the semantics view once per process and reuse the answer.
-
-    Racing callers may both probe; the result is identical, so the extra DESC
-    is cheaper than serializing every describe_table on a lock.
-    """
-    cached = state.semantics_capability
-    if cached is not None:
-        return cached
-    capability = _probe_table_semantics(cursor)
-    if capability.cacheable:
-        state.semantics_capability = capability
-    return capability
-
-
-def _parse_semantic_json(value, column: str, expected: type):
-    """Decode a semantics JSON column, keeping the raw text when it is not usable.
-
-    Returns (parsed, raw, error): callers surface raw/error instead of dropping
-    a payload whose shape this version does not expect.
-    """
-    if not value:
-        return None, None, None
-    try:
-        parsed = json.loads(value)
-    except (TypeError, json.JSONDecodeError) as e:
-        return None, value, str(e)
-    if not isinstance(parsed, expected):
-        shape = "object" if expected is dict else "array"
-        return None, value, f"{column} is not a JSON {shape}"
-    return parsed, None, None
-
-
-def _fetch_table_semantics(
-    state: AppState, cursor, table_schema: str, table_name: str
-) -> dict:
-    """Read the table_semantics view, degrading if it or a column is absent."""
-    capability = _table_semantics_capability(state, cursor)
-    if not capability.available:
-        return {
-            "included": True,
-            "available": False,
-            "found": False,
-            "reason": capability.status,
-            "error": capability.detail,
-        }
-
-    columns = capability.selectable(SEMANTICS_COLUMNS)
-    missing = [c for c in SEMANTICS_COLUMNS if c not in capability.columns]
-    try:
-        cursor.execute(
-            f"SELECT {', '.join(columns)} FROM {SEMANTICS_VIEW} "
-            "WHERE table_schema = %s AND table_name = %s",
-            (table_schema, table_name),
-        )
-        # fetchall() drains the unbuffered cursor before the next query runs;
-        # the WHERE clause matches at most one row.
-        rows = cursor.fetchall()
-        row = rows[0] if rows else None
-    except Error as e:
-        return {
-            "included": True,
-            "available": False,
-            "found": False,
-            "reason": "error",
-            "error": str(e),
-        }
-
-    result = {"included": True, "available": True, "found": row is not None}
-    if missing:
-        result["missing_columns"] = missing
-    if row is None:
-        return result
-
-    values = dict(zip(columns, row))
-    options, raw_options, options_error = _parse_semantic_json(
-        values.get("semantic_options"), "semantic_options", dict
-    )
-    declarations, raw_declarations, declarations_error = _parse_semantic_json(
-        values.get("entity_declarations"), "entity_declarations", list
-    )
-
-    result.update(
-        {
-            "table_catalog": values.get("table_catalog"),
-            "table_schema": values.get("table_schema"),
-            "table_name": values.get("table_name"),
-            "table_id": values.get("table_id"),
-            "signal_type": values.get("signal_type"),
-            "source": values.get("source"),
-            "source_version": values.get("source_version"),
-            "pipeline": values.get("pipeline"),
-            "metadata_quality": values.get("metadata_quality"),
-            "options": options or {},
-        }
-    )
-    if raw_options is not None:
-        result["raw_options"] = raw_options
-        result["options_parse_error"] = options_error
-    if declarations is not None:
-        result["entity_declarations"] = declarations
-    if raw_declarations is not None:
-        result["raw_entity_declarations"] = raw_declarations
-        result["entity_declarations_parse_error"] = declarations_error
-    return result
-
-
 def _fetch_table_samples(
     cursor, state, table_schema: str, table_name: str, schema: dict, sample_limit: int
 ) -> dict:
@@ -455,152 +274,9 @@ def _fetch_table_samples(
         }
 
 
-def _search_terms(query: str) -> list[str]:
-    """Split a concept query into distinct searchable terms.
-
-    Underscores become separators so that a query for `used memory` still
-    matches `redis___used_memory_`.
-    """
-    normalized = query.lower().replace("_", " ")
-    terms = (
-        term
-        for term in re.findall(r"[a-z0-9.:-]+", normalized)
-        if len(term) > 1 and term not in SEARCH_STOP_WORDS
-    )
-    return list(dict.fromkeys(terms))[:MAX_SEARCH_TERMS]
-
-
-def _escape_like(term: str) -> str:
-    """Neutralize LIKE wildcards in a user-supplied term.
-
-    GreptimeDB rejects the ESCAPE clause but treats a backslash as the escape
-    character, so the term is escaped for the default and bound as a parameter.
-    """
-    for char in ("\\", "%", "_"):
-        term = term.replace(char, "\\" + char)
-    return term
-
-
-def _matched_terms(terms: list[str], searchable: str) -> list[str]:
-    """Return the terms a candidate matched, for ranking.
-
-    Terms of one or two characters must match a whole token: a substring test
-    would let `geo` match `range of`.
-    """
-    normalized = searchable.lower()
-    tokens = set(re.findall(r"[a-z0-9]+", normalized))
-    return [
-        term
-        for term in terms
-        if term in tokens or (len(term) > 2 and term in normalized)
-    ]
-
-
-def _entity_declaration_guidance(semantics: dict) -> list[str]:
-    """Explain what the table contributes to the semantic graph, if anything."""
-    if not semantics.get("included") or not semantics.get("found"):
-        return []
-
-    if "entity_declarations" in (semantics.get("missing_columns") or []):
-        return [
-            "This GreptimeDB version does not expose entity_declarations, so "
-            "the entities this table contributes to the semantic graph cannot "
-            "be read here. Absence is a version limit, not evidence that the "
-            "table declares none."
-        ]
-
-    declarations = semantics.get("entity_declarations")
-    if not declarations:
-        return [
-            "This table declares no semantic entities, so it contributes no "
-            "nodes to the semantic graph. Its rows are still queryable."
-        ]
-
-    types = sorted(
-        {
-            str(item.get("entity_type"))
-            for item in declarations
-            if isinstance(item, dict) and item.get("entity_type")
-        }
-    )
-    guidance = []
-    if types:
-        guidance.append(
-            f"This table contributes these semantic entities: {', '.join(types)}. "
-            "Each declaration's id lists the identifying columns, in order."
-        )
-    # The declared/convention split and a dropped id_qualifier are the only
-    # observable causes of one process appearing under two entity ids.
-    guidance.append(
-        "Check origin and id_qualifier on each declaration before treating two "
-        "ids as two things. An explicit declaration replaces the built-in "
-        "convention for that entity type outright, so one that omits "
-        "id_qualifier silently drops the qualifier the convention would have "
-        "applied, and the same process can then appear under two ids."
-    )
-    return guidance
-
-
-def _build_table_guidance(schema: dict, semantics: dict, samples: dict) -> list[str]:
-    """Derive query hints from signal type, metric kind, and sample ordering."""
-    guidance = []
-    if semantics.get("included") and not semantics.get("available", True):
-        if semantics.get("reason") == "permission_denied":
-            guidance.append(
-                f"{SEMANTICS_VIEW} exists but this account cannot read it. "
-                "Signal type and query pattern below are schema/sample-based "
-                "inference."
-            )
-        else:
-            guidance.append(
-                "Table semantic metadata is unavailable. The connected "
-                f"GreptimeDB version may not support {SEMANTICS_VIEW}."
-            )
-    elif semantics.get("included") and not semantics.get("found"):
-        guidance.append(
-            "No table semantic metadata was found. Treat signal type and "
-            "query pattern as schema/sample-based inference."
-        )
-
-    guidance.extend(_entity_declaration_guidance(semantics))
-
-    signal_type = semantics.get("signal_type")
-    options = semantics.get("options") or {}
-    metric_type = options.get("metric.type")
-    metadata_quality = semantics.get("metadata_quality")
-
-    if signal_type == "metric":
-        if metric_type == "counter":
-            guidance.append(
-                "This table is a counter metric. Prefer rate or increase "
-                "queries for trend analysis."
-            )
-        elif metric_type == "gauge":
-            guidance.append(
-                "This table is a gauge metric. Prefer absolute value, avg, "
-                "min, max, or percentile analysis."
-            )
-        elif metric_type == "histogram":
-            guidance.append(
-                "This table is a histogram metric. Prefer bucket/count/sum "
-                "based percentile analysis."
-            )
-        if metadata_quality == "inferred":
-            guidance.append(
-                "Metric type was inferred from naming. Re-check the query "
-                "choice if the metric name is non-standard."
-            )
-    elif signal_type == "trace":
-        guidance.append(
-            "This table represents traces. Prefer latency, error span, and "
-            "service-level aggregation queries."
-        )
-    elif signal_type == "log":
-        guidance.append(
-            "This table represents logs. Prefer full-text search plus "
-            "severity, time, and service aggregations."
-        )
-
+def _build_table_guidance(schema: dict, profile: dict, samples: dict) -> list[str]:
+    """Combine semantic query hints with hints about the profile itself."""
+    guidance = semantics.guidance(profile)
     if samples.get("included") and samples.get("strategy") == "latest_by_time_index":
         guidance.append(
             f"Sample rows are ordered by time index {schema.get('time_index')} descending."
@@ -909,8 +585,8 @@ async def describe_table(
                         default=str,
                     )
                 table_comment = _fetch_table_comment(cursor, table_schema, table_name)
-                semantics = (
-                    _fetch_table_semantics(state, cursor, table_schema, table_name)
+                profile = (
+                    state.table_semantics.fetch(cursor, table_schema, table_name)
                     if include_semantics
                     else {"included": False}
                 )
@@ -927,9 +603,9 @@ async def describe_table(
                     "table_name": table_name,
                     **({"table_comment": table_comment} if table_comment else {}),
                     "schema": schema,
-                    "semantics": semantics,
+                    "semantics": profile,
                     "samples": samples,
-                    "guidance": _build_table_guidance(schema, semantics, samples),
+                    "guidance": _build_table_guidance(schema, profile, samples),
                 }
                 return json.dumps(result, ensure_ascii=False, indent=2, default=str)
 
@@ -950,90 +626,6 @@ async def describe_table(
         )
 
 
-def _search_table_semantics_sql(
-    capability: SemanticsCapability,
-    terms: list[str],
-    table_schema: str,
-    signal_type: str | None,
-) -> tuple[str, list]:
-    """Build the candidate query and its bound parameters."""
-    columns = capability.selectable(SEMANTICS_COLUMNS)
-    searchable = capability.selectable(SEARCH_COLUMNS)
-
-    predicates = ["table_schema = %s"]
-    params: list = [table_schema]
-    if signal_type:
-        predicates.append("signal_type = %s")
-        params.append(signal_type)
-
-    for term in terms:
-        pattern = f"%{_escape_like(term)}%"
-        # COALESCE keeps a NULL column from making the whole OR group NULL,
-        # which would drop rows that matched on another column.
-        clauses = [f"LOWER(COALESCE({column}, '')) LIKE %s" for column in searchable]
-        predicates.append(f"({' OR '.join(clauses)})")
-        params.extend([pattern] * len(clauses))
-
-    sql = (
-        f"SELECT {', '.join(columns)} FROM {SEMANTICS_VIEW} "
-        f"WHERE {' AND '.join(predicates)} "
-        f"ORDER BY table_name LIMIT {SEARCH_SCAN_LIMIT}"
-    )
-    return sql, params
-
-
-def _rank_search_candidates(
-    columns: list[str], rows: list, terms: list[str]
-) -> list[dict]:
-    """Score rows by matched terms, dropping rows no term actually matched."""
-    candidates = []
-    for row in rows:
-        values = dict(zip(columns, row))
-        options, raw_options, _ = _parse_semantic_json(
-            values.get("semantic_options"), "semantic_options", dict
-        )
-        declarations, raw_declarations, _ = _parse_semantic_json(
-            values.get("entity_declarations"), "entity_declarations", list
-        )
-        searchable = " ".join(
-            str(part)
-            for part in (
-                values.get("table_name"),
-                values.get("semantic_options"),
-                values.get("entity_declarations"),
-            )
-            if part
-        )
-        matched = _matched_terms(terms, searchable)
-        if not matched:
-            # The SQL LIKE matched a substring the ranking rules reject, such
-            # as a short term inside a longer word.
-            continue
-        candidate = {
-            "table": values.get("table_name"),
-            "signal_type": values.get("signal_type"),
-            "source": values.get("source"),
-            "source_version": values.get("source_version"),
-            "pipeline": values.get("pipeline"),
-            "metadata_quality": values.get("metadata_quality"),
-            "matched_terms": matched,
-        }
-        if options:
-            candidate["semantic_options"] = options
-        elif raw_options:
-            candidate["semantic_options"] = raw_options
-        if declarations:
-            candidate["entity_declarations"] = declarations
-        elif raw_declarations:
-            candidate["entity_declarations"] = raw_declarations
-        candidates.append(candidate)
-
-    candidates.sort(
-        key=lambda item: (-len(item["matched_terms"]), str(item["table"]).lower())
-    )
-    return candidates
-
-
 @tool()
 async def search_table_semantics(
     query: Annotated[
@@ -1043,11 +635,11 @@ async def search_table_semantics(
     ],
     signal_type: Annotated[
         str | None,
-        f"Restrict results to one signal type: {', '.join(VALID_SIGNAL_TYPES)}",
+        f"Restrict results to one signal type: {', '.join(semantics.VALID_SIGNAL_TYPES)}",
     ] = None,
     limit: Annotated[
-        int, f"Maximum tables to return (1-{MAX_SEARCH_LIMIT}, default: 50)"
-    ] = MAX_SEARCH_LIMIT,
+        int, f"Maximum tables to return (1-{semantics.MAX_SEARCH_LIMIT}, default: 50)"
+    ] = semantics.MAX_SEARCH_LIMIT,
 ) -> str:
     """Find tables by observability concept when the right table name is unknown.
 
@@ -1066,56 +658,14 @@ async def search_table_semantics(
     rather than concluding it is not there.
     """
     state = get_state()
-    if not query or not query.strip():
-        raise ValueError("query is required")
-    if signal_type is not None and signal_type not in VALID_SIGNAL_TYPES:
-        raise ValueError(
-            f"Invalid signal_type: {signal_type}. "
-            f"Must be one of: {', '.join(VALID_SIGNAL_TYPES)}"
-        )
-    terms = _search_terms(query)
-    if not terms:
-        raise ValueError(
-            "query must contain at least one term of two or more characters"
-        )
-    limit = max(1, min(limit, MAX_SEARCH_LIMIT))
-    table_schema = state.db_config["database"]
+    request = semantics.SearchRequest.parse(query, signal_type, limit)
 
     def _sync_search():
         with state.get_connection() as conn:
             with conn.cursor() as cursor:
-                capability = _table_semantics_capability(state, cursor)
-                if not capability.available:
-                    return {
-                        "query": query,
-                        "terms": terms,
-                        "available": False,
-                        "reason": capability.status,
-                        "error": capability.detail,
-                        "matches": [],
-                    }
-                sql, params = _search_table_semantics_sql(
-                    capability, terms, table_schema, signal_type
+                return state.table_semantics.search(
+                    cursor, state.db_config["database"], request
                 )
-                cursor.execute(sql, params)
-                columns = [desc[0] for desc in cursor.description]
-                rows = cursor.fetchall()
-                candidates = _rank_search_candidates(columns, rows, terms)
-                result = {
-                    "query": query,
-                    "terms": terms,
-                    "available": True,
-                    "signal_type": signal_type,
-                    "searched_columns": capability.selectable(SEARCH_COLUMNS),
-                    "matched_table_count": len(candidates),
-                    "matches": candidates[:limit],
-                    "truncated": len(rows) >= SEARCH_SCAN_LIMIT
-                    or len(candidates) > limit,
-                }
-                missing = [c for c in SEARCH_COLUMNS if not capability.has(c)]
-                if missing:
-                    result["unsearched_columns"] = missing
-                return result
 
     try:
         result = await asyncio.to_thread(_sync_search)

--- a/src/greptimedb_mcp_server/server.py
+++ b/src/greptimedb_mcp_server/server.py
@@ -677,14 +677,7 @@ async def search_table_semantics(
         result = await asyncio.to_thread(_sync_search)
     except Error as e:
         logger.error(f"Error searching table semantics for '{query}': {e}")
-        # Same envelope as every other outcome, so a caller can parse one shape.
-        result = {
-            "query": query,
-            "available": False,
-            "reason": "error",
-            "error": str(e),
-            "matches": [],
-        }
+        result = semantics.search_failure(request, "error", str(e))
     return json.dumps(result, ensure_ascii=False, indent=2, default=str)
 
 

--- a/src/greptimedb_mcp_server/server.py
+++ b/src/greptimedb_mcp_server/server.py
@@ -634,7 +634,9 @@ async def search_table_semantics(
     ],
     signal_type: Annotated[
         str | None,
-        f"Restrict results to one signal type: {', '.join(semantics.VALID_SIGNAL_TYPES)}",
+        "Restrict results to one signal type: "
+        f"{', '.join(semantics.VALID_SIGNAL_TYPES)}. Tables whose signal type "
+        "was never stamped are excluded by this filter.",
     ] = None,
     limit: Annotated[
         int, f"Maximum tables to return (1-{semantics.MAX_SEARCH_LIMIT}, default: 50)"
@@ -648,8 +650,13 @@ async def search_table_semantics(
 
     It searches schema metadata only, never telemetry row values, so it can say
     which table holds Redis memory usage but not which row belongs to
-    `Redis02`. Once it returns candidates, query their data or describe one of
-    them; do not describe every candidate in turn.
+    `Redis02`. It ranks on the values in that metadata, not on the schema's own
+    key names, so search for `gauge` or `bytes` rather than `metric type`. Once
+    it returns candidates, query their data or describe one of them; do not
+    describe every candidate in turn.
+
+    It covers only the database this server is connected to, unlike
+    describe_table, which accepts a schema-qualified name.
 
     Only tables carrying a `greptime.semantic.*` option, or one a built-in
     convention derives a declaration for, are visible here. A table absent from
@@ -670,7 +677,14 @@ async def search_table_semantics(
         result = await asyncio.to_thread(_sync_search)
     except Error as e:
         logger.error(f"Error searching table semantics for '{query}': {e}")
-        return f"Error searching table semantics: {str(e)}"
+        # Same envelope as every other outcome, so a caller can parse one shape.
+        result = {
+            "query": query,
+            "available": False,
+            "reason": "error",
+            "error": str(e),
+            "matches": [],
+        }
     return json.dumps(result, ensure_ascii=False, indent=2, default=str)
 
 

--- a/src/greptimedb_mcp_server/utils.py
+++ b/src/greptimedb_mcp_server/utils.py
@@ -140,18 +140,6 @@ def validate_table_name(table: str) -> str:
     return table
 
 
-def escape_like_pattern(value: str) -> str:
-    """Neutralize LIKE wildcards in a value that is bound as a parameter.
-
-    GreptimeDB rejects the ESCAPE clause but treats a backslash as the escape
-    character, so the value is escaped for that default. Parameter binding
-    handles quoting; this only keeps `%` and `_` from matching as wildcards.
-    """
-    for char in ("\\", "%", "_"):
-        value = value.replace(char, "\\" + char)
-    return value
-
-
 def validate_tql_param(value: str, name: str) -> str:
     """Validate TQL parameter doesn't contain injection characters."""
     if not value:

--- a/src/greptimedb_mcp_server/utils.py
+++ b/src/greptimedb_mcp_server/utils.py
@@ -140,6 +140,18 @@ def validate_table_name(table: str) -> str:
     return table
 
 
+def escape_like_pattern(value: str) -> str:
+    """Neutralize LIKE wildcards in a value that is bound as a parameter.
+
+    GreptimeDB rejects the ESCAPE clause but treats a backslash as the escape
+    character, so the value is escaped for that default. Parameter binding
+    handles quoting; this only keeps `%` and `_` from matching as wildcards.
+    """
+    for char in ("\\", "%", "_"):
+        value = value.replace(char, "\\" + char)
+    return value
+
+
 def validate_tql_param(value: str, name: str) -> str:
     """Validate TQL parameter doesn't contain injection characters."""
     if not value:

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -42,6 +42,8 @@ class SeedData:
     base_ms: int
     hosts: tuple[str, ...]
     points_per_host: int
+    # False before GreptimeDB 1.3, which is where entity options were added.
+    entity_declared: bool = False
 
     @property
     def row_count(self) -> int:
@@ -75,11 +77,26 @@ def seed(db):
     for table in (METRICS_TABLE, CREDENTIALS_TABLE):
         cursor.execute(f"DROP TABLE IF EXISTS {table}")
 
+    # The semantic options make the table visible to search_table_semantics.
+    # Entity declarations are added separately: the option key does not exist
+    # before GreptimeDB 1.3 and CREATE TABLE rejects it outright.
     cursor.execute(f"""CREATE TABLE {METRICS_TABLE} (
             ts TIMESTAMP TIME INDEX,
             host STRING PRIMARY KEY,
             cpu DOUBLE
+        ) WITH (
+            'greptime.semantic.signal_type' = 'metric',
+            'greptime.semantic.metric.type' = 'gauge',
+            'greptime.semantic.metric.unit' = 'percent'
         )""")
+    try:
+        cursor.execute(
+            f"ALTER TABLE {METRICS_TABLE} "
+            "SET 'greptime.semantic.entity.host.id' = 'host'"
+        )
+        entity_declared = True
+    except mysql.connector.Error:
+        entity_declared = False
     # `password` is a reserved word in GreptimeDB's parser, hence user_password.
     # Both column names still match the default masking patterns.
     cursor.execute(f"""CREATE TABLE {CREDENTIALS_TABLE} (
@@ -110,6 +127,7 @@ def seed(db):
         base_ms=base_ms,
         hosts=METRIC_HOSTS,
         points_per_host=METRIC_POINTS,
+        entity_declared=entity_declared,
     )
 
     for table in (METRICS_TABLE, CREDENTIALS_TABLE):

--- a/tests/integration/test_e2e.py
+++ b/tests/integration/test_e2e.py
@@ -284,3 +284,46 @@ async def test_prompts_render(seed):
         assert "table_operation" in prompts
         rendered = await client.get_prompt("table_operation", {"table": METRICS_TABLE})
     assert METRICS_TABLE in rendered.messages[0].content.text
+
+
+async def test_search_table_semantics_finds_the_seeded_table(seed):
+    async with stdio_session() as client:
+        payload = json.loads(
+            await call_text(client, "search_table_semantics", {"query": "cpu metrics"})
+        )
+
+    assert payload["available"] is True
+    tables = [match["table"] for match in payload["matches"]]
+    assert METRICS_TABLE in tables
+
+    match = next(m for m in payload["matches"] if m["table"] == METRICS_TABLE)
+    assert match["signal_type"] == "metric"
+    assert match["semantic_options"]["metric.type"] == "gauge"
+
+
+async def test_describe_table_reports_entity_declarations(seed):
+    async with stdio_session() as client:
+        profile = json.loads(
+            await call_text(
+                client,
+                "describe_table",
+                {"table": METRICS_TABLE, "include_samples": False},
+            )
+        )
+
+    semantics = profile["semantics"]
+    assert semantics["found"] is True
+    assert semantics["signal_type"] == "metric"
+
+    if seed.entity_declared:
+        types = {d["entity_type"] for d in semantics["entity_declarations"]}
+        assert "host" in types
+        assert any("id_qualifier" in line for line in profile["guidance"])
+    else:
+        # Older GreptimeDB: the column is absent and must be reported as a
+        # version limit rather than as "this table declares nothing".
+        assert semantics["missing_columns"] == ["entity_declarations"]
+        assert any(
+            "does not expose entity_declarations" in line
+            for line in profile["guidance"]
+        )

--- a/tests/integration/test_e2e.py
+++ b/tests/integration/test_e2e.py
@@ -286,17 +286,20 @@ async def test_prompts_render(seed):
     assert METRICS_TABLE in rendered.messages[0].content.text
 
 
-async def test_search_table_semantics_finds_the_seeded_table(seed):
+async def test_search_table_semantics(seed):
+    """Terms are ORed: a table matching only one of them is still a candidate."""
     async with stdio_session() as client:
         payload = json.loads(
-            await call_text(client, "search_table_semantics", {"query": "cpu metrics"})
+            await call_text(
+                client,
+                "search_table_semantics",
+                {"query": "cpu saturation percentile"},
+            )
         )
 
     assert payload["available"] is True
-    tables = [match["table"] for match in payload["matches"]]
-    assert METRICS_TABLE in tables
-
     match = next(m for m in payload["matches"] if m["table"] == METRICS_TABLE)
+    assert match["matched_terms"] == ["cpu"]
     assert match["signal_type"] == "metric"
     assert match["semantic_options"]["metric.type"] == "gauge"
 

--- a/tests/test_semantics.py
+++ b/tests/test_semantics.py
@@ -13,8 +13,8 @@ from greptimedb_mcp_server.semantics import (
     _build_search_sql,
     _rank_candidates,
     guidance,
-    matched_terms,
-    search_terms,
+    _matched_terms,
+    _search_terms,
 )
 
 from conftest import SEMANTICS_VIEW_COLUMNS
@@ -78,15 +78,6 @@ def test_search_sql_binds_terms_instead_of_inlining_them():
     assert params[1:] == ["%memory%"] * 3
 
 
-def test_search_sql_escapes_like_wildcards():
-    """A term containing % or _ must match literally, not as a wildcard."""
-    _, params = _build_search_sql(
-        FULL, SearchRequest("raw", ["a_b%c"], None, 10), "testdb"
-    )
-
-    assert params[1] == "%a\\_b\\%c%"
-
-
 def test_search_sql_coalesces_nullable_columns():
     """A NULL column would make the whole OR group NULL and drop the row."""
     sql, _ = _build_search_sql(FULL, request("memory"), "testdb")
@@ -106,7 +97,7 @@ def test_search_sql_omits_columns_the_view_lacks():
 
 
 def test_search_terms_splits_underscores_and_drops_stop_words():
-    assert search_terms("redis_used_memory for the host") == [
+    assert _search_terms("redis_used_memory for the host") == [
         "redis",
         "used",
         "memory",
@@ -115,7 +106,7 @@ def test_search_terms_splits_underscores_and_drops_stop_words():
 
 
 def test_search_terms_deduplicates_and_caps():
-    terms = search_terms(" ".join(f"term{i}" for i in range(20)) + " term0")
+    terms = _search_terms(" ".join(f"term{i}" for i in range(20)) + " term0")
 
     assert len(terms) == semantics.MAX_SEARCH_TERMS
     assert len(set(terms)) == len(terms)
@@ -137,25 +128,25 @@ def test_search_sql_ors_the_terms_together():
 
 def test_search_terms_keeps_io_as_one_token():
     """Split on the slash, `I/O` becomes two one-letter terms and vanishes."""
-    assert search_terms("node disk write I/O") == ["node", "disk", "write", "io"]
-    assert search_terms("system_io_w_s") == ["system", "io"]
-    assert search_terms("CPU of a pod") == ["cpu", "pod"]
+    assert _search_terms("node disk write I/O") == ["node", "disk", "write", "io"]
+    assert _search_terms("system_io_w_s") == ["system", "io"]
+    assert _search_terms("CPU of a pod") == ["cpu", "pod"]
 
 
 def test_matched_terms_expands_io_direction_abbreviations():
     """`system_io_w_s` is a write metric; the query says `write`."""
-    assert matched_terms(["write", "io"], "system_io_w_s") == ["write", "io"]
-    assert matched_terms(["read", "io"], "system_io_r_s") == ["read", "io"]
+    assert _matched_terms(["write", "io"], "system_io_w_s") == ["write", "io"]
+    assert _matched_terms(["read", "io"], "system_io_r_s") == ["read", "io"]
 
 
 def test_matched_terms_does_not_expand_nonadjacent_io_tokens():
-    assert matched_terms(["write", "io"], "unrelated_w_metric_io") == ["io"]
+    assert _matched_terms(["write", "io"], "unrelated_w_metric_io") == ["io"]
 
 
 def test_matched_terms_requires_whole_token_for_short_terms():
     """`geo` must not match `range of` once punctuation is stripped."""
-    assert matched_terms(["geo"], "range of requests") == []
-    assert matched_terms(["geo"], "geo service") == ["geo"]
+    assert _matched_terms(["geo"], "range of requests") == []
+    assert _matched_terms(["geo"], "geo service") == ["geo"]
 
 
 def test_rank_candidates_keeps_field_types_stable():
@@ -173,7 +164,7 @@ def test_rank_candidates_keeps_field_types_stable():
 
 
 def test_matched_terms_allows_substring_for_longer_terms():
-    assert matched_terms(["memory"], "redis_used_memory_bytes") == ["memory"]
+    assert _matched_terms(["memory"], "redis_used_memory_bytes") == ["memory"]
 
 
 def test_search_request_rejects_an_unusable_query():

--- a/tests/test_semantics.py
+++ b/tests/test_semantics.py
@@ -1,0 +1,277 @@
+"""Tests for table semantics capability negotiation and concept search."""
+
+import json
+
+import pytest
+from mysql.connector import Error
+
+from greptimedb_mcp_server import server
+from greptimedb_mcp_server.server import (
+    SEMANTICS_COLUMNS,
+    SemanticsCapability,
+    _entity_declaration_guidance,
+    _matched_terms,
+    _search_table_semantics_sql,
+    _search_terms,
+    _table_semantics_capability,
+    search_table_semantics,
+)
+
+from conftest import SEMANTICS_VIEW_COLUMNS
+
+FULL = SemanticsCapability("available", columns=frozenset(SEMANTICS_VIEW_COLUMNS))
+NO_DECLARATIONS = SemanticsCapability(
+    "available",
+    columns=frozenset(set(SEMANTICS_VIEW_COLUMNS) - {"entity_declarations"}),
+)
+
+
+class ProbeCursor:
+    """Cursor that fails the capability probe with a chosen MySQL error."""
+
+    def __init__(self, errno):
+        self.errno = errno
+        self.probes = 0
+
+    def execute(self, query, args=None):
+        self.probes += 1
+        # conftest replaces mysql.connector with a mock whose Error takes no
+        # keyword arguments, so the errno is attached rather than constructed.
+        error = Error("probe failed")
+        error.errno = self.errno
+        raise error
+
+    def fetchall(self):
+        return []
+
+
+def _state():
+    return server.AppState(
+        db_config={"database": "testdb"},
+        pool_config={},
+        templates={},
+        http_base_url="http://localhost:4000",
+    )
+
+
+@pytest.fixture
+def app_state():
+    """Install application state backed by the mocked MySQL connection."""
+    server._state = server.AppState(
+        db_config={
+            "host": "localhost",
+            "port": 4002,
+            "user": "testuser",
+            "password": "testpassword",
+            "database": "testdb",
+            "time_zone": "",
+        },
+        pool_config={"pool_name": "greptimedb_pool", "pool_size": 5},
+        templates={},
+        http_base_url="http://localhost:4000",
+        mask_enabled=False,
+    )
+    yield server._state
+    server._state = None
+
+
+def test_search_sql_binds_terms_instead_of_inlining_them():
+    sql, params = _search_table_semantics_sql(FULL, ["memory"], "testdb", None)
+
+    assert "memory" not in sql
+    assert params[0] == "testdb"
+    assert params[1:] == ["%memory%"] * 3
+
+
+def test_search_sql_escapes_like_wildcards():
+    """A term containing % or _ must match literally, not as a wildcard."""
+    _, params = _search_table_semantics_sql(FULL, ["a_b%c"], "testdb", None)
+
+    assert params[1] == "%a\\_b\\%c%"
+
+
+def test_search_sql_coalesces_nullable_columns():
+    """A NULL column would make the whole OR group NULL and drop the row."""
+    sql, _ = _search_table_semantics_sql(FULL, ["memory"], "testdb", None)
+
+    assert "LOWER(COALESCE(semantic_options, ''))" in sql
+    assert "LOWER(COALESCE(entity_declarations, ''))" in sql
+
+
+def test_search_sql_omits_columns_the_view_lacks():
+    """Selecting a column the view lacks fails the whole statement to plan."""
+    sql, params = _search_table_semantics_sql(
+        NO_DECLARATIONS, ["memory"], "testdb", "metric"
+    )
+
+    assert "entity_declarations" not in sql
+    assert params == ["testdb", "metric", "%memory%", "%memory%"]
+
+
+def test_search_sql_filters_by_signal_type():
+    sql, params = _search_table_semantics_sql(FULL, ["memory"], "testdb", "log")
+
+    assert "signal_type = %s" in sql
+    assert "log" in params
+
+
+def test_search_terms_splits_underscores_and_drops_stop_words():
+    assert _search_terms("redis_used_memory for the host") == [
+        "redis",
+        "used",
+        "memory",
+        "host",
+    ]
+
+
+def test_search_terms_deduplicates_and_caps():
+    terms = _search_terms(" ".join(f"term{i}" for i in range(20)) + " term0")
+
+    assert len(terms) == server.MAX_SEARCH_TERMS
+    assert len(set(terms)) == len(terms)
+
+
+def test_matched_terms_requires_whole_token_for_short_terms():
+    """`geo` must not match `range of` once punctuation is stripped."""
+    assert _matched_terms(["geo"], "range of requests") == []
+    assert _matched_terms(["geo"], "geo service") == ["geo"]
+
+
+def test_matched_terms_allows_substring_for_longer_terms():
+    assert _matched_terms(["memory"], "redis_used_memory_bytes") == ["memory"]
+
+
+@pytest.mark.parametrize(
+    "errno,expected",
+    [
+        (1146, "unavailable"),
+        (1142, "permission_denied"),
+        (1105, "error"),
+    ],
+)
+def test_capability_probe_classifies_failures(errno, expected):
+    state = _state()
+
+    capability = _table_semantics_capability(state, ProbeCursor(errno))
+
+    assert capability.status == expected
+    assert capability.available is False
+
+
+def test_capability_probe_does_not_cache_transient_failures():
+    """An unclassified error must not disable semantics for the process."""
+    state = _state()
+    cursor = ProbeCursor(1105)
+
+    _table_semantics_capability(state, cursor)
+    _table_semantics_capability(state, cursor)
+
+    assert state.semantics_capability is None
+    assert cursor.probes == 2
+
+
+def test_capability_probe_caches_a_missing_view():
+    state = _state()
+    cursor = ProbeCursor(1146)
+
+    _table_semantics_capability(state, cursor)
+    _table_semantics_capability(state, cursor)
+
+    assert state.semantics_capability.status == "unavailable"
+    assert cursor.probes == 1
+
+
+def test_entity_declaration_guidance_flags_a_version_limit():
+    guidance = _entity_declaration_guidance(
+        {
+            "included": True,
+            "found": True,
+            "missing_columns": ["entity_declarations"],
+        }
+    )
+
+    assert len(guidance) == 1
+    assert "does not expose entity_declarations" in guidance[0]
+    assert "not evidence" in guidance[0]
+
+
+def test_entity_declaration_guidance_lists_declared_types():
+    guidance = _entity_declaration_guidance(
+        {
+            "included": True,
+            "found": True,
+            "entity_declarations": [
+                {"entity_type": "service", "id": ["service_name"]},
+                {"entity_type": "host", "id": ["host"]},
+            ],
+        }
+    )
+
+    assert "host, service" in guidance[0]
+    assert any("id_qualifier" in line for line in guidance)
+
+
+def test_entity_declaration_guidance_when_table_declares_none():
+    guidance = _entity_declaration_guidance(
+        {"included": True, "found": True, "entity_declarations": []}
+    )
+
+    assert len(guidance) == 1
+    assert "declares no semantic entities" in guidance[0]
+
+
+@pytest.mark.asyncio
+async def test_search_ranks_by_matched_term_count(app_state):
+    result = json.loads(await search_table_semantics(query="redis used memory"))
+
+    assert result["available"] is True
+    assert result["matches"][0]["table"] == "redis_used_memory"
+    assert result["matches"][0]["matched_terms"] == ["redis", "used", "memory"]
+    assert result["matched_table_count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_search_reports_columns_the_view_lacks(app_state):
+    """An older view searches less, and the result has to say so."""
+    app_state.semantics_capability = NO_DECLARATIONS
+
+    result = json.loads(await search_table_semantics(query="redis memory"))
+
+    assert result["searched_columns"] == ["table_name", "semantic_options"]
+    assert result["unsearched_columns"] == ["entity_declarations"]
+
+
+@pytest.mark.asyncio
+async def test_search_rejects_an_unusable_query(app_state):
+    from mcp.server.mcpserver.exceptions import ToolError
+
+    with pytest.raises(ToolError) as excinfo:
+        await search_table_semantics(query="of the")
+    assert "at least one term" in str(excinfo.value)
+
+
+@pytest.mark.asyncio
+async def test_search_rejects_an_unknown_signal_type(app_state):
+    from mcp.server.mcpserver.exceptions import ToolError
+
+    with pytest.raises(ToolError) as excinfo:
+        await search_table_semantics(query="memory", signal_type="metrics")
+    assert "Invalid signal_type" in str(excinfo.value)
+
+
+@pytest.mark.asyncio
+async def test_search_reports_an_unavailable_view(app_state):
+    server._state.semantics_capability = SemanticsCapability(
+        "unavailable", detail="Table not found"
+    )
+
+    result = json.loads(await search_table_semantics(query="memory"))
+
+    assert result["available"] is False
+    assert result["reason"] == "unavailable"
+    assert result["matches"] == []
+
+
+def test_semantics_columns_match_the_documented_view():
+    """The SELECT list is the 1.3 view; drift here silently drops a field."""
+    assert SEMANTICS_COLUMNS == SEMANTICS_VIEW_COLUMNS

--- a/tests/test_semantics.py
+++ b/tests/test_semantics.py
@@ -105,13 +105,6 @@ def test_search_sql_omits_columns_the_view_lacks():
     assert params == ["testdb", "metric", "%memory%", "%memory%"]
 
 
-def test_search_sql_filters_by_signal_type():
-    sql, params = _build_search_sql(FULL, request("memory", "log"), "testdb")
-
-    assert "signal_type = %s" in sql
-    assert "log" in params
-
-
 def test_search_terms_splits_underscores_and_drops_stop_words():
     assert search_terms("redis_used_memory for the host") == [
         "redis",
@@ -126,6 +119,37 @@ def test_search_terms_deduplicates_and_caps():
 
     assert len(terms) == semantics.MAX_SEARCH_TERMS
     assert len(set(terms)) == len(terms)
+
+
+def test_search_sql_ors_the_terms_together():
+    """ANDing terms would require every word and flatten the ranking."""
+    sql, params = _build_search_sql(FULL, request("redis memory usage"), "testdb")
+
+    where = sql.split(" WHERE ", 1)[1].split(" ORDER BY", 1)[0]
+    schema_filter, term_group = where.split(" AND ", 1)
+
+    assert schema_filter == "table_schema = %s"
+    # One OR group per term, ORed with each other, and nothing ANDed inside.
+    assert term_group.count("LIKE %s") == 9
+    assert " AND " not in term_group
+    assert params[1:] == ["%redis%"] * 3 + ["%memory%"] * 3 + ["%usage%"] * 3
+
+
+def test_search_terms_keeps_io_as_one_token():
+    """Split on the slash, `I/O` becomes two one-letter terms and vanishes."""
+    assert search_terms("node disk write I/O") == ["node", "disk", "write", "io"]
+    assert search_terms("system_io_w_s") == ["system", "io"]
+    assert search_terms("CPU of a pod") == ["cpu", "pod"]
+
+
+def test_matched_terms_expands_io_direction_abbreviations():
+    """`system_io_w_s` is a write metric; the query says `write`."""
+    assert matched_terms(["write", "io"], "system_io_w_s") == ["write", "io"]
+    assert matched_terms(["read", "io"], "system_io_r_s") == ["read", "io"]
+
+
+def test_matched_terms_does_not_expand_nonadjacent_io_tokens():
+    assert matched_terms(["write", "io"], "unrelated_w_metric_io") == ["io"]
 
 
 def test_matched_terms_requires_whole_token_for_short_terms():
@@ -162,13 +186,6 @@ def test_search_request_rejects_an_unknown_signal_type():
     with pytest.raises(ValueError) as excinfo:
         SearchRequest.parse("memory", "metrics")
     assert "Invalid signal_type" in str(excinfo.value)
-
-
-def test_search_request_clamps_the_limit():
-    assert SearchRequest.parse("memory", None, 10_000).limit == (
-        semantics.MAX_SEARCH_LIMIT
-    )
-    assert SearchRequest.parse("memory", None, 0).limit == 1
 
 
 @pytest.mark.parametrize(
@@ -290,8 +307,3 @@ async def test_search_reports_an_unavailable_view(app_state):
     assert result["available"] is False
     assert result["reason"] == "unavailable"
     assert result["matches"] == []
-
-
-def test_columns_match_the_documented_view():
-    """The SELECT list is the 1.3 view; drift here silently drops a field."""
-    assert semantics.COLUMNS == SEMANTICS_VIEW_COLUMNS

--- a/tests/test_semantics.py
+++ b/tests/test_semantics.py
@@ -5,22 +5,22 @@ import json
 import pytest
 from mysql.connector import Error
 
-from greptimedb_mcp_server import server
-from greptimedb_mcp_server.server import (
-    SEMANTICS_COLUMNS,
-    SemanticsCapability,
-    _entity_declaration_guidance,
-    _matched_terms,
-    _search_table_semantics_sql,
-    _search_terms,
-    _table_semantics_capability,
-    search_table_semantics,
+from greptimedb_mcp_server import semantics, server
+from greptimedb_mcp_server.semantics import (
+    Capability,
+    SearchRequest,
+    SemanticsView,
+    _build_search_sql,
+    _rank_candidates,
+    guidance,
+    matched_terms,
+    search_terms,
 )
 
 from conftest import SEMANTICS_VIEW_COLUMNS
 
-FULL = SemanticsCapability("available", columns=frozenset(SEMANTICS_VIEW_COLUMNS))
-NO_DECLARATIONS = SemanticsCapability(
+FULL = Capability("available", columns=frozenset(SEMANTICS_VIEW_COLUMNS))
+NO_DECLARATIONS = Capability(
     "available",
     columns=frozenset(set(SEMANTICS_VIEW_COLUMNS) - {"entity_declarations"}),
 )
@@ -45,13 +45,8 @@ class ProbeCursor:
         return []
 
 
-def _state():
-    return server.AppState(
-        db_config={"database": "testdb"},
-        pool_config={},
-        templates={},
-        http_base_url="http://localhost:4000",
-    )
+def request(query, signal_type=None, limit=semantics.MAX_SEARCH_LIMIT):
+    return SearchRequest.parse(query, signal_type, limit)
 
 
 @pytest.fixture
@@ -76,7 +71,7 @@ def app_state():
 
 
 def test_search_sql_binds_terms_instead_of_inlining_them():
-    sql, params = _search_table_semantics_sql(FULL, ["memory"], "testdb", None)
+    sql, params = _build_search_sql(FULL, request("memory"), "testdb")
 
     assert "memory" not in sql
     assert params[0] == "testdb"
@@ -85,14 +80,16 @@ def test_search_sql_binds_terms_instead_of_inlining_them():
 
 def test_search_sql_escapes_like_wildcards():
     """A term containing % or _ must match literally, not as a wildcard."""
-    _, params = _search_table_semantics_sql(FULL, ["a_b%c"], "testdb", None)
+    _, params = _build_search_sql(
+        FULL, SearchRequest("raw", ["a_b%c"], None, 10), "testdb"
+    )
 
     assert params[1] == "%a\\_b\\%c%"
 
 
 def test_search_sql_coalesces_nullable_columns():
     """A NULL column would make the whole OR group NULL and drop the row."""
-    sql, _ = _search_table_semantics_sql(FULL, ["memory"], "testdb", None)
+    sql, _ = _build_search_sql(FULL, request("memory"), "testdb")
 
     assert "LOWER(COALESCE(semantic_options, ''))" in sql
     assert "LOWER(COALESCE(entity_declarations, ''))" in sql
@@ -100,8 +97,8 @@ def test_search_sql_coalesces_nullable_columns():
 
 def test_search_sql_omits_columns_the_view_lacks():
     """Selecting a column the view lacks fails the whole statement to plan."""
-    sql, params = _search_table_semantics_sql(
-        NO_DECLARATIONS, ["memory"], "testdb", "metric"
+    sql, params = _build_search_sql(
+        NO_DECLARATIONS, request("memory", "metric"), "testdb"
     )
 
     assert "entity_declarations" not in sql
@@ -109,14 +106,14 @@ def test_search_sql_omits_columns_the_view_lacks():
 
 
 def test_search_sql_filters_by_signal_type():
-    sql, params = _search_table_semantics_sql(FULL, ["memory"], "testdb", "log")
+    sql, params = _build_search_sql(FULL, request("memory", "log"), "testdb")
 
     assert "signal_type = %s" in sql
     assert "log" in params
 
 
 def test_search_terms_splits_underscores_and_drops_stop_words():
-    assert _search_terms("redis_used_memory for the host") == [
+    assert search_terms("redis_used_memory for the host") == [
         "redis",
         "used",
         "memory",
@@ -125,20 +122,53 @@ def test_search_terms_splits_underscores_and_drops_stop_words():
 
 
 def test_search_terms_deduplicates_and_caps():
-    terms = _search_terms(" ".join(f"term{i}" for i in range(20)) + " term0")
+    terms = search_terms(" ".join(f"term{i}" for i in range(20)) + " term0")
 
-    assert len(terms) == server.MAX_SEARCH_TERMS
+    assert len(terms) == semantics.MAX_SEARCH_TERMS
     assert len(set(terms)) == len(terms)
 
 
 def test_matched_terms_requires_whole_token_for_short_terms():
     """`geo` must not match `range of` once punctuation is stripped."""
-    assert _matched_terms(["geo"], "range of requests") == []
-    assert _matched_terms(["geo"], "geo service") == ["geo"]
+    assert matched_terms(["geo"], "range of requests") == []
+    assert matched_terms(["geo"], "geo service") == ["geo"]
+
+
+def test_rank_candidates_keeps_field_types_stable():
+    """A malformed payload must not turn semantic_options into a string."""
+    columns = ["table_name", "semantic_options", "entity_declarations"]
+
+    [malformed] = _rank_candidates(
+        columns, [("redis_memory", "not json", None)], ["redis"]
+    )
+    [empty] = _rank_candidates(columns, [("redis_memory", "{}", None)], ["redis"])
+
+    assert "semantic_options" not in malformed
+    assert malformed["raw_options"] == "not json"
+    assert empty["semantic_options"] == {}
 
 
 def test_matched_terms_allows_substring_for_longer_terms():
-    assert _matched_terms(["memory"], "redis_used_memory_bytes") == ["memory"]
+    assert matched_terms(["memory"], "redis_used_memory_bytes") == ["memory"]
+
+
+def test_search_request_rejects_an_unusable_query():
+    with pytest.raises(ValueError) as excinfo:
+        SearchRequest.parse("of the")
+    assert "at least one term" in str(excinfo.value)
+
+
+def test_search_request_rejects_an_unknown_signal_type():
+    with pytest.raises(ValueError) as excinfo:
+        SearchRequest.parse("memory", "metrics")
+    assert "Invalid signal_type" in str(excinfo.value)
+
+
+def test_search_request_clamps_the_limit():
+    assert SearchRequest.parse("memory", None, 10_000).limit == (
+        semantics.MAX_SEARCH_LIMIT
+    )
+    assert SearchRequest.parse("memory", None, 0).limit == 1
 
 
 @pytest.mark.parametrize(
@@ -150,9 +180,7 @@ def test_matched_terms_allows_substring_for_longer_terms():
     ],
 )
 def test_capability_probe_classifies_failures(errno, expected):
-    state = _state()
-
-    capability = _table_semantics_capability(state, ProbeCursor(errno))
+    capability = SemanticsView().negotiate(ProbeCursor(errno))
 
     assert capability.status == expected
     assert capability.available is False
@@ -160,45 +188,45 @@ def test_capability_probe_classifies_failures(errno, expected):
 
 def test_capability_probe_does_not_cache_transient_failures():
     """An unclassified error must not disable semantics for the process."""
-    state = _state()
+    view = SemanticsView()
     cursor = ProbeCursor(1105)
 
-    _table_semantics_capability(state, cursor)
-    _table_semantics_capability(state, cursor)
+    view.negotiate(cursor)
+    view.negotiate(cursor)
 
-    assert state.semantics_capability is None
     assert cursor.probes == 2
 
 
 def test_capability_probe_caches_a_missing_view():
-    state = _state()
+    view = SemanticsView()
     cursor = ProbeCursor(1146)
 
-    _table_semantics_capability(state, cursor)
-    _table_semantics_capability(state, cursor)
+    view.negotiate(cursor)
+    view.negotiate(cursor)
 
-    assert state.semantics_capability.status == "unavailable"
     assert cursor.probes == 1
 
 
-def test_entity_declaration_guidance_flags_a_version_limit():
-    guidance = _entity_declaration_guidance(
+def test_guidance_flags_a_version_limit():
+    hints = guidance(
         {
             "included": True,
+            "available": True,
             "found": True,
             "missing_columns": ["entity_declarations"],
         }
     )
 
-    assert len(guidance) == 1
-    assert "does not expose entity_declarations" in guidance[0]
-    assert "not evidence" in guidance[0]
+    assert len(hints) == 1
+    assert "does not expose entity_declarations" in hints[0]
+    assert "not evidence" in hints[0]
 
 
-def test_entity_declaration_guidance_lists_declared_types():
-    guidance = _entity_declaration_guidance(
+def test_guidance_lists_declared_entity_types():
+    hints = guidance(
         {
             "included": True,
+            "available": True,
             "found": True,
             "entity_declarations": [
                 {"entity_type": "service", "id": ["service_name"]},
@@ -207,22 +235,32 @@ def test_entity_declaration_guidance_lists_declared_types():
         }
     )
 
-    assert "host, service" in guidance[0]
-    assert any("id_qualifier" in line for line in guidance)
+    assert "host, service" in hints[0]
+    assert any("id_qualifier" in line for line in hints)
 
 
-def test_entity_declaration_guidance_when_table_declares_none():
-    guidance = _entity_declaration_guidance(
-        {"included": True, "found": True, "entity_declarations": []}
+def test_guidance_when_the_table_declares_no_entities():
+    hints = guidance(
+        {"included": True, "available": True, "found": True, "entity_declarations": []}
     )
 
-    assert len(guidance) == 1
-    assert "declares no semantic entities" in guidance[0]
+    assert len(hints) == 1
+    assert "declares no semantic entities" in hints[0]
+
+
+def test_guidance_separates_permission_denied_from_an_absent_view():
+    denied = guidance(
+        {"included": True, "available": False, "reason": "permission_denied"}
+    )
+    absent = guidance({"included": True, "available": False, "reason": "unavailable"})
+
+    assert "cannot read it" in denied[0]
+    assert "may not support" in absent[0]
 
 
 @pytest.mark.asyncio
 async def test_search_ranks_by_matched_term_count(app_state):
-    result = json.loads(await search_table_semantics(query="redis used memory"))
+    result = json.loads(await server.search_table_semantics(query="redis used memory"))
 
     assert result["available"] is True
     assert result["matches"][0]["table"] == "redis_used_memory"
@@ -233,45 +271,27 @@ async def test_search_ranks_by_matched_term_count(app_state):
 @pytest.mark.asyncio
 async def test_search_reports_columns_the_view_lacks(app_state):
     """An older view searches less, and the result has to say so."""
-    app_state.semantics_capability = NO_DECLARATIONS
+    app_state.table_semantics = SemanticsView(capability=NO_DECLARATIONS)
 
-    result = json.loads(await search_table_semantics(query="redis memory"))
+    result = json.loads(await server.search_table_semantics(query="redis memory"))
 
     assert result["searched_columns"] == ["table_name", "semantic_options"]
     assert result["unsearched_columns"] == ["entity_declarations"]
 
 
 @pytest.mark.asyncio
-async def test_search_rejects_an_unusable_query(app_state):
-    from mcp.server.mcpserver.exceptions import ToolError
-
-    with pytest.raises(ToolError) as excinfo:
-        await search_table_semantics(query="of the")
-    assert "at least one term" in str(excinfo.value)
-
-
-@pytest.mark.asyncio
-async def test_search_rejects_an_unknown_signal_type(app_state):
-    from mcp.server.mcpserver.exceptions import ToolError
-
-    with pytest.raises(ToolError) as excinfo:
-        await search_table_semantics(query="memory", signal_type="metrics")
-    assert "Invalid signal_type" in str(excinfo.value)
-
-
-@pytest.mark.asyncio
 async def test_search_reports_an_unavailable_view(app_state):
-    server._state.semantics_capability = SemanticsCapability(
-        "unavailable", detail="Table not found"
+    app_state.table_semantics = SemanticsView(
+        capability=Capability("unavailable", detail="Table not found")
     )
 
-    result = json.loads(await search_table_semantics(query="memory"))
+    result = json.loads(await server.search_table_semantics(query="memory"))
 
     assert result["available"] is False
     assert result["reason"] == "unavailable"
     assert result["matches"] == []
 
 
-def test_semantics_columns_match_the_documented_view():
+def test_columns_match_the_documented_view():
     """The SELECT list is the 1.3 view; drift here silently drops a field."""
-    assert SEMANTICS_COLUMNS == SEMANTICS_VIEW_COLUMNS
+    assert semantics.COLUMNS == SEMANTICS_VIEW_COLUMNS

--- a/tests/test_semantics.py
+++ b/tests/test_semantics.py
@@ -71,12 +71,17 @@ def app_state():
     server._state = None
 
 
+def _where(sql):
+    return sql.split(" WHERE ", 1)[1].split(" ORDER BY", 1)[0]
+
+
 def test_search_sql_binds_terms_instead_of_inlining_them():
     sql, params = _build_search_sql(FULL, request("memory"), "testdb")
 
     assert "memory" not in sql
-    assert params[0] == "testdb"
-    assert params[1:] == ["%memory%"] * 3
+    # once for the relevance score, once for the filter, over three columns
+    assert params.count("%memory%") == 6
+    assert "testdb" in params
 
 
 def test_search_sql_coalesces_nullable_columns():
@@ -94,16 +99,13 @@ def test_search_sql_omits_columns_the_view_lacks():
     )
 
     assert "entity_declarations" not in sql
-    assert params == ["testdb", "metric", "%memory%", "%memory%"]
+    # two searchable columns left, scored once and filtered once
+    assert params.count("%memory%") == 4
+    assert params.count("metric") == 1
 
 
-def test_search_terms_splits_underscores_and_drops_stop_words():
-    assert _search_terms("redis_used_memory for the host") == [
-        "redis",
-        "used",
-        "memory",
-        "host",
-    ]
+def test_search_terms_drops_stop_words_and_single_characters():
+    assert _search_terms("cpu of a pod") == ["cpu", "pod"]
 
 
 def test_search_terms_deduplicates_and_caps():
@@ -117,21 +119,30 @@ def test_search_sql_ors_the_terms_together():
     """ANDing terms would require every word and flatten the ranking."""
     sql, params = _build_search_sql(FULL, request("redis memory usage"), "testdb")
 
-    where = sql.split(" WHERE ", 1)[1].split(" ORDER BY", 1)[0]
-    schema_filter, term_group = where.split(" AND ", 1)
+    schema_filter, term_group = _where(sql).split(" AND ", 1)
 
     assert schema_filter == "table_schema = %s"
     # One OR group per term, ORed with each other, and nothing ANDed inside.
     assert term_group.count("LIKE %s") == 9
     assert " AND " not in term_group
-    assert params[1:] == ["%redis%"] * 3 + ["%memory%"] * 3 + ["%usage%"] * 3
+    for term in ("%redis%", "%memory%", "%usage%"):
+        assert params.count(term) == 6
+
+
+def test_scan_is_ordered_by_relevance_not_by_name():
+    """Ordering by name would cut the candidate set alphabetically, so a table
+    hitting every term can lose to one hitting a single term and never reach
+    ranking at all."""
+    sql, _ = _build_search_sql(FULL, request("redis used memory"), "testdb")
+
+    assert "ORDER BY term_hits DESC, table_name" in sql
+    assert sql.count("CASE WHEN") == 3
 
 
 def test_search_terms_keeps_io_as_one_token():
     """Split on the slash, `I/O` becomes two one-letter terms and vanishes."""
     assert _search_terms("node disk write I/O") == ["node", "disk", "write", "io"]
     assert _search_terms("system_io_w_s") == ["system", "io"]
-    assert _search_terms("CPU of a pod") == ["cpu", "pod"]
 
 
 def test_matched_terms_expands_io_direction_abbreviations():
@@ -202,10 +213,6 @@ def test_rank_candidates_keeps_field_types_stable():
     assert "semantic_options" not in malformed
     assert malformed["raw_options"] == "not json"
     assert empty["semantic_options"] == {}
-
-
-def test_matched_terms_allows_substring_for_longer_terms():
-    assert _matched_terms(["memory"], "redis_used_memory_bytes") == ["memory"]
 
 
 def test_search_request_rejects_an_unusable_query():
@@ -416,6 +423,7 @@ async def test_every_search_outcome_shares_one_shape(app_state):
         assert common <= set(payload), sorted(common - set(payload))
     assert ok["available"] is True
     assert unavailable["available"] is False
+    assert unavailable["reason"] == "unavailable"
     assert failed["available"] is False
 
 

--- a/tests/test_semantics.py
+++ b/tests/test_semantics.py
@@ -390,6 +390,36 @@ async def test_search_reports_columns_the_view_lacks(app_state):
 
 
 @pytest.mark.asyncio
+async def test_every_search_outcome_shares_one_shape(app_state):
+    """A caller parses one schema whether the search worked or not."""
+    common = {
+        "query",
+        "terms",
+        "signal_type",
+        "available",
+        "matched_table_count",
+        "matches",
+    }
+
+    ok = json.loads(await server.search_table_semantics(query="redis memory"))
+
+    app_state.table_semantics = SemanticsView(
+        capability=Capability("unavailable", detail="Table not found")
+    )
+    unavailable = json.loads(await server.search_table_semantics(query="redis memory"))
+
+    failed = semantics.search_failure(
+        SearchRequest.parse("redis memory"), "error", "connection lost"
+    )
+
+    for payload in (ok, unavailable, failed):
+        assert common <= set(payload), sorted(common - set(payload))
+    assert ok["available"] is True
+    assert unavailable["available"] is False
+    assert failed["available"] is False
+
+
+@pytest.mark.asyncio
 async def test_search_reports_an_unavailable_view(app_state):
     app_state.table_semantics = SemanticsView(
         capability=Capability("unavailable", detail="Table not found")

--- a/tests/test_semantics.py
+++ b/tests/test_semantics.py
@@ -8,6 +8,7 @@ from mysql.connector import Error
 from greptimedb_mcp_server import semantics, server
 from greptimedb_mcp_server.semantics import (
     Capability,
+    _tokens,
     SearchRequest,
     SemanticsView,
     _build_search_sql,
@@ -141,6 +142,46 @@ def test_matched_terms_expands_io_direction_abbreviations():
 
 def test_matched_terms_does_not_expand_nonadjacent_io_tokens():
     assert _matched_terms(["write", "io"], "unrelated_w_metric_io") == ["io"]
+
+
+def test_tokens_split_identifiers_however_they_are_written():
+    """snake, camel, acronym, dotted and numeric all reduce to the same words."""
+    assert _tokens("used_memory_bytes") == ["used", "memory", "bytes"]
+    assert _tokens("usedMemoryBytes") == ["used", "memory", "bytes"]
+    assert _tokens("nodeCPUSeconds") == ["node", "cpu", "seconds"]
+    assert _tokens("os.linux.mem-free") == ["os", "linux", "mem", "free"]
+    assert _tokens("redis_Redis_6379_Redis___used_memory_") == [
+        "redis",
+        "redis",
+        "6379",
+        "redis",
+        "used",
+        "memory",
+    ]
+
+
+def test_camel_case_names_are_searchable():
+    """This worked before only as a side effect of substring matching."""
+    assert _matched_terms(["memory"], "usedMemoryBytes") == ["memory"]
+    assert _matched_terms(["cpu"], "nodeCPUSeconds") == ["cpu"]
+
+
+def test_a_term_matches_a_token_prefix():
+    assert _matched_terms(["mem"], "os_linux_memory_usage_percent") == ["mem"]
+    assert _matched_terms(["dur"], "http_request_duration_seconds") == ["dur"]
+
+
+def test_prefix_matching_does_not_cross_token_boundaries():
+    """A substring test let `geo` match `rangeof`; a prefix per token cannot."""
+    assert _matched_terms(["geo"], "range_of_requests") == []
+    assert _matched_terms(["geo"], "rangeof_requests") == []
+
+
+def test_search_recalls_the_rows_a_synonym_would_match():
+    """Nothing in `system_io_w_s` contains `write`, so the scan must ask for io."""
+    _, params = _build_search_sql(FULL, request("write"), "testdb")
+
+    assert "%io%" in params
 
 
 def test_matched_terms_requires_whole_token_for_short_terms():

--- a/tests/test_semantics.py
+++ b/tests/test_semantics.py
@@ -230,6 +230,15 @@ def test_guidance_flags_a_version_limit():
     assert "not evidence" in hints[0]
 
 
+def _declared(**declaration):
+    return {
+        "included": True,
+        "available": True,
+        "found": True,
+        "entity_declarations": [declaration],
+    }
+
+
 def test_guidance_lists_declared_entity_types():
     hints = guidance(
         {
@@ -244,7 +253,59 @@ def test_guidance_lists_declared_entity_types():
     )
 
     assert "host, service" in hints[0]
-    assert any("id_qualifier" in line for line in hints)
+
+
+def test_guidance_warns_only_when_a_qualifier_can_be_dropped():
+    """Only a hand-written declaration can drop the convention's qualifier."""
+    at_risk = guidance(_declared(entity_type="service", id=["name"], origin="declared"))
+    qualified = guidance(
+        _declared(
+            entity_type="service",
+            id=["name"],
+            origin="declared",
+            id_qualifier="namespace",
+        )
+    )
+    conventional = guidance(
+        _declared(entity_type="service", id=["name"], origin="convention")
+    )
+
+    assert any("id_qualifier" in line for line in at_risk)
+    assert not any("id_qualifier" in line for line in qualified)
+    assert not any("id_qualifier" in line for line in conventional)
+
+
+def test_guidance_reports_a_failed_read_as_a_failed_read():
+    """A transient query failure is not a statement about the server version."""
+    hints = guidance(
+        {"included": True, "available": False, "reason": "error", "error": "timeout"}
+    )
+
+    assert "may not support" not in hints[0]
+    assert "retry" in hints[0]
+
+
+def test_ranking_ignores_the_schemas_own_key_names():
+    """Structural words would otherwise score every table alike."""
+    columns = ["table_name", "semantic_options", "entity_declarations"]
+    rows = [
+        ("it_cpu", '{"metric.type":"gauge","metric.unit":"percent"}', None),
+        ("orders_total", '{"metric.type":"counter"}', None),
+    ]
+
+    assert _rank_candidates(columns, rows, ["metric", "type", "unit"]) == []
+    # Values still rank, so the vocabulary a user actually searches survives.
+    [gauge] = _rank_candidates(columns, rows, ["gauge"])
+    assert gauge["table"] == "it_cpu"
+
+
+def test_ranking_still_sees_entity_declaration_values():
+    columns = ["table_name", "semantic_options", "entity_declarations"]
+    rows = [("t", None, '[{"entity_type":"k8s.pod","id":["pod"]}]')]
+
+    [match] = _rank_candidates(columns, rows, ["pod"])
+
+    assert match["matched_terms"] == ["pod"]
 
 
 def test_guidance_when_the_table_declares_no_entities():

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -28,6 +28,8 @@ from greptimedb_mcp_server.server import (
 )
 from greptimedb_mcp_server.utils import templates_loader
 
+from conftest import SEMANTICS_VIEW_COLUMNS
+
 
 @pytest.fixture(autouse=True)
 def setup_state():
@@ -321,7 +323,9 @@ async def test_describe_table_non_object_semantic_options():
 
         def execute(self, query, args=None):
             self.query = query
-            if "information_schema.table_semantics" in query:
+            if query.startswith("DESC TABLE information_schema.table_semantics"):
+                self._results = [(name,) for name in SEMANTICS_VIEW_COLUMNS]
+            elif "information_schema.table_semantics" in query:
                 self._results = [
                     (
                         "greptime",
@@ -330,9 +334,11 @@ async def test_describe_table_non_object_semantic_options():
                         1,
                         "metric",
                         "opentelemetry",
+                        "1.0",
                         "",
                         "declared",
                         "[1, 2, 3]",
+                        None,
                     )
                 ]
             elif "information_schema.tables" in query:


### PR DESCRIPTION
Adds concept search over table semantics, and exposes the semantics fields `describe_table` was dropping.

## Changes

- `describe_table` reads `source_version` and `entity_declarations`, which the previous nine-column SELECT omitted. Guidance names the entity types a table contributes, and warns about a dropped `id_qualifier` only for declarations that are `declared` with none.
- New `search_table_semantics(query, signal_type?, limit=50)`. Searches table names, semantic options and entity declarations; ranks by how many query terms each table hits.
- The server probes the semantics view's column list once per process and builds every query from what is exposed. A failed probe is classified `unavailable`, `permission_denied` or `error`; only the first two are cached. A profile reports `missing_columns`.
- Integration CI runs against GreptimeDB 1.2 and 1.3 at pinned digests. 1.3 covers `entity_declarations`; 1.2 covers the column-negotiation path.
- Version 0.6.0.

## What the tool returns

Captured against GreptimeDB 1.3 with `redis_used_memory_bytes`, `redis_mem_fragmentation_ratio`, `system_io_w_s`, `http_server_request_duration`, `app_logs`, plus one table carrying no semantic options.

`search_table_semantics(query="redis memory usage")`

```json
{
  "query": "redis memory usage",
  "terms": ["redis", "memory", "usage"],
  "available": true,
  "signal_type": null,
  "searched_columns": ["table_name", "semantic_options", "entity_declarations"],
  "matched_table_count": 2,
  "matches": [
    {
      "table": "redis_used_memory_bytes",
      "signal_type": "metric",
      "source": null, "source_version": null, "pipeline": null, "metadata_quality": null,
      "matched_terms": ["redis", "memory"],
      "semantic_options": {"entity.host.id": "host", "metric.type": "gauge", "metric.unit": "By"},
      "entity_declarations": [{"entity_type": "host", "origin": "declared", "id": ["host"]}]
    },
    {
      "table": "redis_mem_fragmentation_ratio",
      "signal_type": "metric",
      "source": null, "source_version": null, "pipeline": null, "metadata_quality": null,
      "matched_terms": ["redis"],
      "semantic_options": {"metric.type": "gauge"}
    }
  ],
  "truncated": false
}
```

A table does not have to hit every term. `usage` matched nothing; both tables are still returned, ordered by how many terms they hit. `terms` is what the query was tokenized into, and `matched_table_count` is the true total while `matches` stops at `limit`.

Other outcomes, same seed:

| Input | Result |
| --- | --- |
| `query="request latency", signal_type="metric"` | one match, `http_server_request_duration`, `matched_terms: ["request"]` |
| `query="write I/O"` | `terms: ["write", "io"]`, matches `system_io_w_s` with `matched_terms: ["write", "io"]` |
| `query="kafka consumer lag"` | `matched_table_count: 0`, `matches: []`, `available: true` |
| on 1.2, where the view has no `entity_declarations` | `searched_columns: ["table_name", "semantic_options"]`, `unsearched_columns: ["entity_declarations"]` |
| view absent | `available: false`, `reason: "unavailable"`, `error: "Table not found: ..."`, `matches: []` |
| `query="of the"` | `ToolError: query must contain at least one term of two or more characters` |
| `signal_type="metrics"` | `ToolError: Invalid signal_type: metrics. Must be one of: metric, log, trace, event` |

`query`, `terms`, `signal_type`, `available`, `matched_table_count` and `matches` are present in every outcome, so one shape parses all of them.

A table carrying no `greptime.semantic.*` option and no convention-derived declaration is not in the view and can never be found here; `SHOW TABLES` still is the fallback.

## Notes for review

- **Matching rule.** One tokenizer for both query and candidate, splitting on separators and case transitions and keeping acronyms whole, so `used_memory_bytes`, `usedMemoryBytes` and `nodeCPUSeconds` reduce to their words. A term matches a token exactly, or from three characters up as a prefix. Prefixes cannot cross token boundaries.
- **The SQL filter is an over-approximation.** It only bounds what gets read; `_matched_terms` decides what is returned. Rows the filter recalls and the rule rejects are expected.
- **Scan ordering.** The scan orders by term-hit count, not table name. Ordering by name cut the candidate set alphabetically: on a 20k-table schema, searching "redis used memory" omitted the only three-term match. Name is the tie-break, so truncation stays deterministic.
- **Ranking uses JSON values, not keys.** Otherwise "metric type unit" scores a perfect match against every metric table.
- `search_table_semantics` covers only the connected database; `describe_table` still takes `schema.table`. `execute_sql` is unchanged and reaches the same view directly.

## Verification

225 unit tests. Integration on freshly started instances: 20 passed on each of 1.2.0-beta.1 and 1.3.0-alpha.1.